### PR TITLE
소켓 설정 및 연결, 종료에 따른 로직 구현

### DIFF
--- a/connet/build.gradle
+++ b/connet/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
@@ -1,0 +1,25 @@
+package houseInception.connet.socketManager;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SocketManager {
+
+    private final ConcurrentHashMap<Long, WebSocketSession> userSocketMap = new ConcurrentHashMap<>();
+
+    public void addSocket(Long userId, WebSocketSession session){
+        userSocketMap.put(userId, session);
+    }
+
+    public void deleteSocket(WebSocketSession session){
+        for (Long userId : userSocketMap.keySet()) {
+            if(userSocketMap.get(userId).getId().equals(session.getId())){
+                userSocketMap.remove(userId);
+                return;
+            }
+        }
+    }
+}

--- a/connet/src/main/java/houseInception/socket/AuthHandshakeInterceptor.java
+++ b/connet/src/main/java/houseInception/socket/AuthHandshakeInterceptor.java
@@ -1,0 +1,60 @@
+package houseInception.socket;
+
+import houseInception.connet.domain.Status;
+import houseInception.connet.domain.User;
+import houseInception.connet.jwt.JwtTokenProvider;
+import houseInception.connet.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AuthHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        String authHeader = request.getHeaders().getFirst("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return false;
+        }
+
+        String token = authHeader.substring(7);
+        if (isInvalidToken(token) || isInValidUser(token)) {
+            return false;
+        }
+
+        saveUserIdInThreadLocal(token);
+        return true;
+    }
+
+    private void saveUserIdInThreadLocal(String token){
+        String userEmail = tokenProvider.getUserPk(token);
+        User user = userRepository.findByEmailAndStatus(userEmail, Status.ALIVE).orElseThrow();
+
+        MDC.put("socketUserId", String.valueOf(user.getId()));
+    }
+
+    private boolean isInvalidToken(String token){
+        return !tokenProvider.validateToken(token);
+    }
+
+    private boolean isInValidUser(String token){
+        String userEmail = tokenProvider.getUserPk(token);
+        return !userRepository.existsByEmailAndStatus(userEmail, Status.ALIVE);
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/connet/src/main/java/houseInception/socket/SocketConfig.java
+++ b/connet/src/main/java/houseInception/socket/SocketConfig.java
@@ -1,0 +1,21 @@
+package houseInception.socket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@RequiredArgsConstructor
+@Configuration
+public class SocketConfig implements WebSocketConfigurer {
+
+    private final SocketHandler socketHandler;
+    private final AuthHandshakeInterceptor authHandshakeInterceptor;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(socketHandler, "/socket")
+                .setAllowedOrigins("*")
+                .addInterceptors(authHandshakeInterceptor);
+    }
+}

--- a/connet/src/main/java/houseInception/socket/SocketHandler.java
+++ b/connet/src/main/java/houseInception/socket/SocketHandler.java
@@ -1,0 +1,38 @@
+package houseInception.socket;
+
+import houseInception.connet.socketManager.SocketManager;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@RequiredArgsConstructor
+@Component
+public class SocketHandler extends TextWebSocketHandler {
+
+    private final SocketManager socketManager;
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        super.handleTextMessage(session, message);
+
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        super.afterConnectionEstablished(session);
+
+        String userId = MDC.get("socketUserId");
+        socketManager.addSocket(Long.parseLong(userId), session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        socketManager.deleteSocket(session);
+
+        super.afterConnectionClosed(session, status);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호

- #50 

<br />

## 작업 사항

- 소켓 연결 전 핸드셰이크에 인터셉터를 틍록해 토큰을 검증하는 로직 구현
- 소켓 연결 후, 종료 후 사용자의 세션을 관리하는 클래스 설계

<br />

## 기타 사항
<br />
