### PR TITLE
친구 생성시 단방향(요청자 → 수락자)에서 양방향으로 변경 및 친구 기능에 차단된 유저에 대한 검증 추가 등 개발

### DIFF
--- a/connet/build.gradle
+++ b/connet/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	//Mock
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	testImplementation 'org.mockito:mockito-core:4.0.0'
+	testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
 }
 
 tasks.named('test') {

--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -3,9 +3,11 @@ package houseInception.connet.contoller;
 import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.EmailDto;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.response.BaseResultDto;
 import houseInception.connet.service.FriendService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +21,15 @@ public class FriendController {
     @PostMapping("/{targetId}")
     public BaseResponse<BaseResultDto> requestFriend(@PathVariable Long targetId){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        Long resultId = friendService.requestFriend(userId, targetId);
+        Long resultId = friendService.requestFriendById(userId, targetId);
+
+        return BaseResponse.getSimpleRes(resultId);
+    }
+
+    @PostMapping
+    public BaseResponse<BaseResultDto> requestFriend(@RequestBody @Valid EmailDto emailDto){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        Long resultId = friendService.requestFriendByEmail(userId, emailDto.getEmail());
 
         return BaseResponse.getSimpleRes(resultId);
     }

--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -1,9 +1,6 @@
 package houseInception.connet.contoller;
 
-import houseInception.connet.dto.ActiveUserResDto;
-import houseInception.connet.dto.DataListResDto;
-import houseInception.connet.dto.DefaultUserResDto;
-import houseInception.connet.dto.EmailDto;
+import houseInception.connet.dto.*;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.response.BaseResultDto;
 import houseInception.connet.service.FriendService;
@@ -67,9 +64,9 @@ public class FriendController {
     }
 
     @GetMapping
-    public BaseResponse<DataListResDto<ActiveUserResDto>> getFriendList(){
+    public BaseResponse<DataListResDto<ActiveUserResDto>> getFriendList(@ModelAttribute FriendFilterDto friendFilter){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(userId);
+        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(userId, friendFilter);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -1,5 +1,6 @@
 package houseInception.connet.contoller;
 
+import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.response.BaseResponse;
@@ -56,9 +57,9 @@ public class FriendController {
     }
 
     @GetMapping
-    public BaseResponse<DataListResDto<DefaultUserResDto>> getFriendList(){
+    public BaseResponse<DataListResDto<ActiveUserResDto>> getFriendList(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<DefaultUserResDto> result = friendService.getFriendList(userId);
+        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(userId);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/contoller/UserBlockController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/UserBlockController.java
@@ -1,0 +1,26 @@
+package houseInception.connet.contoller;
+
+import houseInception.connet.response.BaseResponse;
+import houseInception.connet.response.BaseResultDto;
+import houseInception.connet.service.UserBlockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/userBlocks")
+@RequiredArgsConstructor
+@RestController
+public class UserBlockController {
+
+    private final UserBlockService userBlockService;
+
+    @PostMapping("/{targetId}")
+    public BaseResponse<BaseResultDto> blockUser(@PathVariable Long targetId){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        Long resultId = userBlockService.blockUser(userId, targetId);
+
+        return BaseResponse.getSimpleRes(resultId);
+    }
+}

--- a/connet/src/main/java/houseInception/connet/contoller/UserController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/UserController.java
@@ -4,12 +4,9 @@ import houseInception.connet.dto.UserResDto;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/user")
+@RequestMapping("/users")
 @RequiredArgsConstructor
 @RestController
 public class UserController {

--- a/connet/src/main/java/houseInception/connet/domain/UserBlock.java
+++ b/connet/src/main/java/houseInception/connet/domain/UserBlock.java
@@ -1,0 +1,32 @@
+package houseInception.connet.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Entity
+public class UserBlock extends BaseTime{
+
+    @Column(name = "userBlockId")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "targetId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User target;
+
+    public static UserBlock create(User user, User target){
+        UserBlock userBlock = new UserBlock();
+        userBlock.user = user;
+        userBlock.target = target;
+        return userBlock;
+    }
+}

--- a/connet/src/main/java/houseInception/connet/dto/ActiveUserResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/ActiveUserResDto.java
@@ -1,0 +1,21 @@
+package houseInception.connet.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ActiveUserResDto {
+
+    private Long userId;
+    private String userName;
+    private String userProfile;
+
+    @QueryProjection
+    public ActiveUserResDto(Long userId, String userName, String userProfile) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfile = userProfile;
+    }
+}

--- a/connet/src/main/java/houseInception/connet/dto/EmailDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/EmailDto.java
@@ -1,0 +1,17 @@
+package houseInception.connet.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailDto {
+
+    @NotBlank
+    private String email;
+}

--- a/connet/src/main/java/houseInception/connet/dto/FriendFilterDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/FriendFilterDto.java
@@ -1,0 +1,15 @@
+package houseInception.connet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendFilterDto {
+
+    private String userName;
+}

--- a/connet/src/main/java/houseInception/connet/event/domain/UserBlockEvent.java
+++ b/connet/src/main/java/houseInception/connet/event/domain/UserBlockEvent.java
@@ -1,0 +1,12 @@
+package houseInception.connet.event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserBlockEvent {
+
+    private Long userId;
+    private Long targetId;
+}

--- a/connet/src/main/java/houseInception/connet/event/publisher/UserBlockEventPublisher.java
+++ b/connet/src/main/java/houseInception/connet/event/publisher/UserBlockEventPublisher.java
@@ -1,0 +1,21 @@
+package houseInception.connet.event.publisher;
+
+import houseInception.connet.domain.User;
+import houseInception.connet.event.domain.UserBlockEvent;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Getter
+@RequiredArgsConstructor
+@Component
+public class UserBlockEventPublisher {
+
+    private final ApplicationEventPublisher publisher;
+
+    public void publishUserBlockEvent(User user, User target){
+        UserBlockEvent event = new UserBlockEvent(user.getId(), target.getId());
+        publisher.publishEvent(event);
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -2,14 +2,14 @@ package houseInception.connet.repository;
 
 import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.FriendFilterDto;
 
 import java.util.List;
 
 public interface FriendCustomRepository {
 
-    List<ActiveUserResDto> findFriendListWithUser(Long userId);
-
-    List<DefaultUserResDto> findFriendRequestList(Long userId);
+    List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto filterDto);
+    List<DefaultUserResDto> getFriendRequestList(Long userId);
 
     boolean existsFriendRequest(Long userId, Long targetId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -1,14 +1,13 @@
 package houseInception.connet.repository;
 
-import houseInception.connet.domain.Friend;
+import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface FriendCustomRepository {
 
-    List<Friend> findFriendListWithUser(Long userId);
+    List<ActiveUserResDto> findFriendListWithUser(Long userId);
 
     List<DefaultUserResDto> findFriendRequestList(Long userId);
 

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 public interface FriendCustomRepository {
 
-    Optional<Friend> findFriendSenderOrReceiver(Long userId1, Long userId2);
     List<Friend> findFriendListWithUser(Long userId);
 
     List<DefaultUserResDto> findFriendRequestList(Long userId);

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -13,5 +13,5 @@ public interface FriendCustomRepository {
 
     List<DefaultUserResDto> findFriendRequestList(Long userId);
 
-    boolean existsFriend(Long userId, Long targetId);
+    boolean existsFriendRequest(Long userId, Long targetId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.domain.Friend;
 import houseInception.connet.domain.QUser;
+import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -34,15 +35,13 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
     }
 
     @Override
-    public List<Friend> findFriendListWithUser(Long userId) {
-        QUser sender = new QUser("sender");
-        QUser receiver = new QUser("receiver");
-
-        return query.selectFrom(friend)
-                .join(friend.sender, sender).fetchJoin()
-                .join(friend.receiver, receiver).fetchJoin()
-                .where((friend.receiver.id.eq(userId).or(friend.sender.id.eq(userId))
-                        .and(friend.acceptStatus.eq(ACCEPT))))
+    public List<ActiveUserResDto> findFriendListWithUser(Long userId) {
+        return query.select(Projections.constructor(ActiveUserResDto.class,
+                        user.id, user.userName, user.userProfile))
+                .from(friend)
+                .join(user).on(user.id.eq(friend.receiver.id))
+                .where(friend.sender.id.eq(userId),
+                        friend.acceptStatus.eq(ACCEPT))
                 .fetch();
     }
 

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -34,18 +34,6 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
     }
 
     @Override
-    public Optional<Friend> findFriendSenderOrReceiver(Long userId1, Long userId2) {
-        Friend findFriend = query.selectFrom(friend)
-                .where(
-                        (friend.sender.id.eq(userId1).and(friend.receiver.id.eq(userId2)))
-                                .or(friend.sender.id.eq(userId2).and(friend.receiver.id.eq(userId1)))
-                )
-                .fetchFirst();
-
-        return Optional.ofNullable(findFriend);
-    }
-
-    @Override
     public List<Friend> findFriendListWithUser(Long userId) {
         QUser sender = new QUser("sender");
         QUser receiver = new QUser("receiver");

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -59,12 +59,13 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
     }
 
     @Override
-    public boolean existsFriend(Long userId, Long targetId) {
+    public boolean existsFriendRequest(Long userId, Long targetId) {
         Long count = query.select(friend.count())
                 .from(friend)
                 .where(
-                        (friend.sender.id.eq(userId).and(friend.receiver.id.eq(targetId)))
-                                .or(friend.sender.id.eq(targetId).and(friend.receiver.id.eq(userId)))
+                        ((friend.sender.id.eq(userId).and(friend.receiver.id.eq(targetId)))
+                                .or(friend.sender.id.eq(targetId).and(friend.receiver.id.eq(userId)))),
+                        friend.acceptStatus.eq(WAIT)
                 )
                 .fetchFirst();
 

--- a/connet/src/main/java/houseInception/connet/repository/FriendRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long>, FriendCustomRepository {
-    boolean existsBySenderIdAndReceiverIdAndAcceptStatus(Long senderId, Long recipientId, FriendStatus acceptStatus);
+
     Optional<Friend> findBySenderIdAndReceiverIdAndAcceptStatus(Long senderId, Long recipientId, FriendStatus acceptStatus);
+
+    boolean existsBySenderIdAndReceiverIdAndAcceptStatus(Long senderId, Long recipientId, FriendStatus acceptStatus);
 }

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockRepository.java
@@ -1,0 +1,7 @@
+package houseInception.connet.repository;
+
+import houseInception.connet.domain.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+}

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockRepository.java
@@ -4,4 +4,6 @@ import houseInception.connet.domain.UserBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    boolean existsByUserIdAndTargetId(Long userId, Long targetId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/UserCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserCustomRepository.java
@@ -3,5 +3,6 @@ package houseInception.connet.repository;
 import houseInception.connet.dto.UserResDto;
 
 public interface UserCustomRepository {
+
     UserResDto findUserByEmailWithFriendRelation(Long userId, String email);
 }

--- a/connet/src/main/java/houseInception/connet/repository/UserRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserRepository.java
@@ -10,5 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findByEmailAndStatus(String email, Status status);
     boolean existsByEmailAndStatus(String email, Status status);
+    boolean existsByIdAndStatus(Long userId, Status status);
     boolean existsByRefreshTokenAndStatus(String refreshToken, Status status);
 }

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -22,6 +22,7 @@ public enum BaseErrorCode implements StatusCode{
     ALREADY_FRIEND_REQUEST(40006, "이미 요청된 관계입니다.", HttpStatus.BAD_REQUEST),
     NO_SUCH_FRIEND_REQUEST(40007, "요청이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     CANT_NOT_REQUEST_SELF(40008, "본인에게 친구 요청을 보낼 수 없습니다.", HttpStatus.BAD_REQUEST),
+    BLOCK_USER(40009, "차단된 유저입니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_GOOGLE_TOKEN(40101, "유효하지 않은 Google Access Token입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -34,16 +34,19 @@ public class FriendService {
         User user = findUser(userId);
         User targetUser = findUser(targetId);
 
-        checkAlreadyFriendRelation(userId, targetId);
-
         if(userId.equals(targetId)){
             throw new FriendException(CANT_NOT_REQUEST_SELF);
         }
 
-        Friend friend = Friend.createFriend(user, targetUser);
-        friendRepository.save(friend);
+        checkAlreadyFriendRelation(userId, targetId);
 
-        return friend.getId();
+        Friend friend1 = Friend.createFriend(user, targetUser);
+        friendRepository.save(friend1);
+
+        Friend friend2 = Friend.createFriend(targetUser, user);
+        friendRepository.save(friend2);
+
+        return friend1.getId();
     }
 
     @Transactional

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -38,7 +38,7 @@ public class FriendService {
             throw new FriendException(CANT_NOT_REQUEST_SELF);
         }
 
-        checkAlreadyFriendRelation(userId, targetId);
+        checkAlreadyFriendRequestOfTwoWay(userId, targetId);
 
         Friend friend = Friend.createFriend(user, targetUser);
         friendRepository.save(friend);
@@ -49,7 +49,7 @@ public class FriendService {
     @Transactional
     public Long acceptFriendRequest(Long userId, Long targetId) {
         User targetUser = findUser(targetId);
-        checkHasFriendRequest(targetId, userId);
+        checkHasFriendRequestOfOneWay(targetId, userId);
         User user = findUser(userId);
 
         Friend requestFriend = findFriend(targetId, userId, WAIT);
@@ -65,7 +65,7 @@ public class FriendService {
     @Transactional
     public Long denyFriendRequest(Long userId, Long targetId) {
         checkExistUser(targetId);
-        checkHasFriendRequest(targetId, userId);
+        checkHasFriendRequestOfOneWay(targetId, userId);
 
         Friend friend = findFriend(targetId, userId, WAIT);
         friendRepository.delete(friend);
@@ -100,13 +100,13 @@ public class FriendService {
         return new DataListResDto<DefaultUserResDto>(0, friendUserList);
     }
 
-    private void checkAlreadyFriendRelation(Long userId, Long targetId){
-        if(friendRepository.existsFriend(userId, targetId)){
+    private void checkAlreadyFriendRequestOfTwoWay(Long userId, Long targetId){
+        if(friendRepository.existsFriendRequest(userId, targetId)){
             throw new FriendException(ALREADY_FRIEND_REQUEST);
         }
     }
 
-    private void checkHasFriendRequest(Long senderId, Long receiverId){
+    private void checkHasFriendRequestOfOneWay(Long senderId, Long receiverId){
         if(!friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(senderId, receiverId, WAIT)){
             throw new FriendException(NO_SUCH_FRIEND_REQUEST);
         }

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Comparator;
 import java.util.List;
 
+import static houseInception.connet.domain.FriendStatus.ACCEPT;
 import static houseInception.connet.domain.FriendStatus.WAIT;
 import static houseInception.connet.response.status.BaseErrorCode.*;
 
@@ -77,10 +78,13 @@ public class FriendService {
     public Long deleteFriend(Long userId, Long targetId) {
         checkExistUser(targetId);
 
-        Friend friend = findFriendSenderOrReceiver(userId, targetId);
-        friendRepository.delete(friend);
+        Friend friend1 = findFriend(userId, targetId, ACCEPT);
+        friendRepository.delete(friend1);
 
-        return friend.getId();
+        Friend friend2 = findFriend(targetId, userId, ACCEPT);
+        friendRepository.delete(friend2);
+
+        return friend1.getId();
     }
 
     public DataListResDto<DefaultUserResDto> getFriendWaitList(Long userId) {
@@ -130,15 +134,6 @@ public class FriendService {
     private Friend findFriend(Long senderId, Long receiverId, FriendStatus acceptStatus){
         Friend friend = friendRepository.findBySenderIdAndReceiverIdAndAcceptStatus(senderId, receiverId, acceptStatus).orElse(null);
         if(friend == null){
-            throw new FriendException(NO_SUCH_FRIEND);
-        }
-
-        return friend;
-    }
-
-    private Friend findFriendSenderOrReceiver(Long user1, Long user2){
-        Friend friend = friendRepository.findFriendSenderOrReceiver(user1, user2).orElse(null);
-        if (friend == null) {
             throw new FriendException(NO_SUCH_FRIEND);
         }
 

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -3,6 +3,7 @@ package houseInception.connet.service;
 import houseInception.connet.domain.Friend;
 import houseInception.connet.domain.FriendStatus;
 import houseInception.connet.domain.User;
+import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.exception.FriendException;
@@ -93,15 +94,10 @@ public class FriendService {
         return new DataListResDto<DefaultUserResDto>(0, requestSenders);
     }
 
-    public DataListResDto<DefaultUserResDto> getFriendList(Long userId) {
-        List<Friend> friendList = friendRepository.findFriendListWithUser(userId);
-        List<DefaultUserResDto> friendUserList = friendList.stream()
-                .map(friend -> friend.getSender().getId().equals(userId) ? friend.getReceiver() : friend.getSender())
-                .sorted(Comparator.comparing(User::getUserName))
-                .map(DefaultUserResDto::new)
-                .toList();
+    public DataListResDto<ActiveUserResDto> getFriendList(Long userId) {
+        List<ActiveUserResDto> friendList = friendRepository.findFriendListWithUser(userId);
 
-        return new DataListResDto<DefaultUserResDto>(0, friendUserList);
+        return new DataListResDto<ActiveUserResDto>(0, friendList);
     }
 
     private void checkAlreadyFriendRequestOfTwoWay(Long userId, Long targetId){

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -56,6 +56,7 @@ public class FriendService {
         requestFriend.accept();
 
         Friend friend = Friend.createFriend(user, targetUser);
+        friend.accept();
         friendRepository.save(friend);
 
         return friend.getId();

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -6,6 +6,7 @@ import houseInception.connet.domain.User;
 import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.FriendFilterDto;
 import houseInception.connet.exception.FriendException;
 import houseInception.connet.exception.UserException;
 import houseInception.connet.repository.FriendRepository;
@@ -110,13 +111,13 @@ public class FriendService {
     }
 
     public DataListResDto<DefaultUserResDto> getFriendWaitList(Long userId) {
-        List<DefaultUserResDto> requestSenders = friendRepository.findFriendRequestList(userId);
+        List<DefaultUserResDto> requestSenders = friendRepository.getFriendRequestList(userId);
 
         return new DataListResDto<DefaultUserResDto>(0, requestSenders);
     }
 
-    public DataListResDto<ActiveUserResDto> getFriendList(Long userId) {
-        List<ActiveUserResDto> friendList = friendRepository.findFriendListWithUser(userId);
+    public DataListResDto<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto friendFilter) {
+        List<ActiveUserResDto> friendList = friendRepository.getFriendList(userId, friendFilter);
 
         return new DataListResDto<ActiveUserResDto>(0, friendList);
     }

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -9,6 +9,7 @@ import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.exception.FriendException;
 import houseInception.connet.exception.UserException;
 import houseInception.connet.repository.FriendRepository;
+import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,11 +31,13 @@ public class FriendService {
 
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
 
     @Transactional
     public Long requestFriend(Long userId, Long targetId) {
-        User user = findUser(userId);
         User targetUser = findUser(targetId);
+        checkUserBlock(userId, targetId);
+        User user = findUser(userId);
 
         if(userId.equals(targetId)){
             throw new FriendException(CANT_NOT_REQUEST_SELF);
@@ -115,6 +118,12 @@ public class FriendService {
     private void checkExistUser(Long userId){
         if (!userRepository.existsById(userId)){
             throw new UserException(NO_SUCH_USER);
+        }
+    }
+
+    private void checkUserBlock(Long userId, Long targetId){
+        if (userBlockRepository.existsByUserIdAndTargetId(userId, targetId)){
+            throw new FriendException(BLOCK_USER);
         }
     }
 

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -40,22 +40,23 @@ public class FriendService {
 
         checkAlreadyFriendRelation(userId, targetId);
 
-        Friend friend1 = Friend.createFriend(user, targetUser);
-        friendRepository.save(friend1);
+        Friend friend = Friend.createFriend(user, targetUser);
+        friendRepository.save(friend);
 
-        Friend friend2 = Friend.createFriend(targetUser, user);
-        friendRepository.save(friend2);
-
-        return friend1.getId();
+        return friend.getId();
     }
 
     @Transactional
     public Long acceptFriendRequest(Long userId, Long targetId) {
-        checkExistUser(targetId);
+        User targetUser = findUser(targetId);
         checkHasFriendRequest(targetId, userId);
+        User user = findUser(userId);
 
-        Friend friend = findFriend(targetId, userId, WAIT);
-        friend.accept();
+        Friend requestFriend = findFriend(targetId, userId, WAIT);
+        requestFriend.accept();
+
+        Friend friend = Friend.createFriend(user, targetUser);
+        friendRepository.save(friend);
 
         return friend.getId();
     }

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -2,8 +2,8 @@ package houseInception.connet.service;
 
 import houseInception.connet.domain.User;
 import houseInception.connet.domain.UserBlock;
-import houseInception.connet.dto.UserResDto;
 import houseInception.connet.exception.UserException;
+import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,25 +16,23 @@ import static houseInception.connet.response.status.BaseErrorCode.NO_SUCH_USER;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
-public class UserService {
+public class UserBlockService {
 
+    private final UserBlockRepository userBlockRepository;
     private final UserRepository userRepository;
 
-    public UserResDto getUserInfo(Long userId, String email) {
-        if (email == null) {
-            return new UserResDto(findUser(userId));
-        }else {
-            return userRepository.findUserByEmailWithFriendRelation(userId, email);
-        }
-    }
+    @Transactional
+    public Long blockUser(Long userId, Long targetId) {
+        User targetUser = findUser(targetId);
+        User user = findUser(userId);
 
-    private User findUserByEmail(String email){
-        User user = userRepository.findByEmailAndStatus(email, ALIVE).orElse(null);
-        if (user == null) {
-            throw new UserException(NO_SUCH_USER);
-        }
+        UserBlock userBlock1 = UserBlock.create(user, targetUser);
+        userBlockRepository.save(userBlock1);
 
-        return user;
+        UserBlock userBlock2 = UserBlock.create(targetUser, user);
+        userBlockRepository.save(userBlock2);
+
+        return userBlock1.getId();
     }
 
     private User findUser(Long userId){

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -36,7 +36,7 @@ public class UserBlockService {
         userBlockRepository.save(userBlock2);
 
         userBlockEventPublisher.publishUserBlockEvent(user, targetUser);
-        
+
         return userBlock1.getId();
     }
 

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -2,6 +2,7 @@ package houseInception.connet.service;
 
 import houseInception.connet.domain.User;
 import houseInception.connet.domain.UserBlock;
+import houseInception.connet.event.publisher.UserBlockEventPublisher;
 import houseInception.connet.exception.UserException;
 import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
@@ -21,6 +22,8 @@ public class UserBlockService {
     private final UserBlockRepository userBlockRepository;
     private final UserRepository userRepository;
 
+    private final UserBlockEventPublisher userBlockEventPublisher;
+
     @Transactional
     public Long blockUser(Long userId, Long targetId) {
         User targetUser = findUser(targetId);
@@ -32,6 +35,8 @@ public class UserBlockService {
         UserBlock userBlock2 = UserBlock.create(targetUser, user);
         userBlockRepository.save(userBlock2);
 
+        userBlockEventPublisher.publishUserBlockEvent(user, targetUser);
+        
         return userBlock1.getId();
     }
 

--- a/connet/src/test/java/houseInception/connet/contoller/UserBlockControllerTest.java
+++ b/connet/src/test/java/houseInception/connet/contoller/UserBlockControllerTest.java
@@ -1,6 +1,5 @@
 package houseInception.connet.contoller;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import houseInception.connet.service.UserBlockService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 

--- a/connet/src/test/java/houseInception/connet/contoller/UserBlockControllerTest.java
+++ b/connet/src/test/java/houseInception/connet/contoller/UserBlockControllerTest.java
@@ -1,0 +1,39 @@
+package houseInception.connet.contoller;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import houseInception.connet.service.UserBlockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class UserBlockControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    UserBlockController userBlockController;
+    @InjectMocks
+    UserBlockService userBlockService;
+
+    @BeforeEach
+    public void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userBlockController)
+                .build();
+    }
+
+    @Test
+    void blockUser() throws Exception {
+        mockMvc.perform(post("/userBlocks/1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -6,6 +6,7 @@ import houseInception.connet.domain.UserBlock;
 import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.FriendFilterDto;
 import houseInception.connet.exception.FriendException;
 import houseInception.connet.repository.FriendRepository;
 import houseInception.connet.repository.UserBlockRepository;
@@ -227,12 +228,39 @@ class FriendServiceTest {
         friendRepository.save(friendD1);
 
         //when
-        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(user1.getId());
+        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(user1.getId(), new FriendFilterDto());
 
         //then
         List<ActiveUserResDto> friendUserList = result.getData();
         assertThat(friendUserList.size()).isEqualTo(3);
         assertThat(friendUserList).extracting("userId").containsExactly(user2.getId(), user3.getId(), user4.getId());
+    }
+
+    @Test
+    void getFriendList_이름_필터() {
+        //given
+        Friend friendA1 = Friend.createFriend(user1, user2);
+        friendA1.accept();
+        friendRepository.save(friendA1);
+        Friend friendA2 = Friend.createFriend(user2, user1);
+        friendA2.accept();
+        friendRepository.save(friendA2);
+
+        Friend friendB1 = Friend.createFriend(user3, user1);
+        friendB1.accept();
+        friendRepository.save(friendB1);
+        Friend friendB2 = Friend.createFriend(user1, user3);
+        friendB2.accept();
+        friendRepository.save(friendB2);
+
+        //when
+        FriendFilterDto filterDto = new FriendFilterDto("2");
+        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(user1.getId(), filterDto);
+
+        //then
+        List<ActiveUserResDto> friendUserList = result.getData();
+        assertThat(friendUserList.size()).isEqualTo(1);
+        assertThat(friendUserList.get(0).getUserId()).isEqualTo(user2.getId());
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -70,14 +70,11 @@ class FriendServiceTest {
     @Test
     void requestFriend() {
         //when
-        Long friendId = friendService.requestFriend(user1.getId(), user2.getId());
+        friendService.requestFriend(user1.getId(), user2.getId());
 
         //then
-        Friend friend = friendRepository.findById(friendId).orElse(null);
-        assertThat(friend).isNotNull();
-        assertThat(friend.getSender().getId()).isEqualTo(user1.getId());
-        assertThat(friend.getReceiver().getId()).isEqualTo(user2.getId());
-        assertThat(friend.getAcceptStatus()).isEqualTo(WAIT);
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), WAIT)).isTrue();
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), WAIT)).isTrue();
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -202,30 +202,21 @@ class FriendServiceTest {
     }
 
     @Test
-    void deleteFriend_sender가() {
+    void deleteFriend() {
         //given
         Friend friend1 = Friend.createFriend(user1, user2);
         friend1.accept();
         friendRepository.save(friend1);
 
-        //when
-        Long friendId = friendService.deleteFriend(user1.getId(), user2.getId());
-
-        //then
-        assertThatThrownBy(() -> friendRepository.findById(friendId).orElseThrow()).isInstanceOf(NoSuchElementException.class);
-    }
-
-    @Test
-    void deleteFriend_recipient가() {
-        //given
-        Friend friend1 = Friend.createFriend(user1, user2);
-        friend1.accept();
-        friendRepository.save(friend1);
+        Friend friend2 = Friend.createFriend(user2, user1);
+        friend2.accept();
+        friendRepository.save(friend2);
 
         //when
-        Long friendId = friendService.deleteFriend(user2.getId(), user1.getId());
+        friendService.deleteFriend(user1.getId(), user2.getId());
 
         //then
-        assertThatThrownBy(() -> friendRepository.findById(friendId).orElseThrow()).isInstanceOf(NoSuchElementException.class);
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), ACCEPT)).isFalse();
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), ACCEPT)).isFalse();
     }
 }

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
 import static houseInception.connet.domain.FriendStatus.ACCEPT;
 import static houseInception.connet.domain.FriendStatus.WAIT;
@@ -50,19 +51,19 @@ class FriendServiceTest {
 
     @BeforeEach
     void beforeEach(){
-        user1 = User.create("user1", null, null, null);
+        user1 = User.create("user1", null, UUID.randomUUID().toString(), null);
         userRepository.save(user1);
 
-        user2 = User.create("user2", null, null, null);
+        user2 = User.create("user2", null, UUID.randomUUID().toString(), null);
         userRepository.save(user2);
 
-        user3 = User.create("user3", null, null, null);
+        user3 = User.create("user3", null, UUID.randomUUID().toString(), null);
         userRepository.save(user3);
 
-        user4 = User.create("user4", null, null, null);
+        user4 = User.create("user4", null, UUID.randomUUID().toString(), null);
         userRepository.save(user4);
 
-        user5 = User.create("user5", null, null, null);
+        user5 = User.create("user5", null, UUID.randomUUID().toString(), null);
         userRepository.save(user5);
     }
 
@@ -73,47 +74,56 @@ class FriendServiceTest {
     }
 
     @Test
-    void requestFriend() {
+    void requestFriendById() {
         //when
-        friendService.requestFriend(user1.getId(), user2.getId());
+        friendService.requestFriendById(user1.getId(), user2.getId());
 
         //then
         assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), WAIT)).isTrue();
     }
 
     @Test
-    void requestFriend_차단된_사용자() {
+    void requestFriend_ById_차단된_사용자() {
         //given
         UserBlock userBlock = UserBlock.create(user1, user2);
         userBlockRepository.save(userBlock);
 
         //when
-        assertThatThrownBy(() -> friendService.requestFriend(user1.getId(), user2.getId())).isInstanceOf(FriendException.class);
+        assertThatThrownBy(() -> friendService.requestFriendById(user1.getId(), user2.getId())).isInstanceOf(FriendException.class);
     }
 
     @Test
-    void requestFriend_이미_요청() {
+    void requestFriend_ById_이미_요청() {
         //given
         Friend friend = Friend.createFriend(user1, user2);
         friendRepository.save(friend);
 
         //when
-        assertThatThrownBy(() -> friendService.requestFriend(user1.getId(), user2.getId())).isInstanceOf(FriendException.class);
+        assertThatThrownBy(() -> friendService.requestFriendById(user1.getId(), user2.getId())).isInstanceOf(FriendException.class);
     }
 
     @Test
-    void requestFriend_상대방이_이미_요청() {
+    void requestFriend_ById_상대방이_이미_요청() {
         //given
         Friend friend = Friend.createFriend(user1, user2);
         friendRepository.save(friend);
 
         //when
-        assertThatThrownBy(() -> friendService.requestFriend(user2.getId(), user1.getId())).isInstanceOf(FriendException.class);
+        assertThatThrownBy(() -> friendService.requestFriendById(user2.getId(), user1.getId())).isInstanceOf(FriendException.class);
     }
 
     @Test
-    void requestFriend_스스로에게_친구_요청() {
-        assertThatThrownBy(() -> friendService.requestFriend(user1.getId(), user1.getId())).isInstanceOf(FriendException.class);
+    void requestFriend_ById_스스로에게_친구_요청() {
+        assertThatThrownBy(() -> friendService.requestFriendById(user1.getId(), user1.getId())).isInstanceOf(FriendException.class);
+    }
+
+    @Test
+    void requestFriendByEmail() {
+        //when
+        friendService.requestFriendByEmail(user1.getId(), user2.getEmail());
+
+        //then
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), WAIT)).isTrue();
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -74,7 +74,6 @@ class FriendServiceTest {
 
         //then
         assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), WAIT)).isTrue();
-        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), WAIT)).isTrue();
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -2,6 +2,7 @@ package houseInception.connet.service;
 
 import houseInception.connet.domain.Friend;
 import houseInception.connet.domain.User;
+import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.exception.FriendException;
@@ -177,26 +178,35 @@ class FriendServiceTest {
     @Test
     void getFriendList() {
         //given
-        Friend friend1 = Friend.createFriend(user1, user2);
-        friend1.accept();
-        friendRepository.save(friend1);
+        Friend friendA1 = Friend.createFriend(user1, user2);
+        friendA1.accept();
+        friendRepository.save(friendA1);
+        Friend friendA2 = Friend.createFriend(user2, user1);
+        friendA2.accept();
+        friendRepository.save(friendA2);
 
-        Friend friend2 = Friend.createFriend(user3, user1);
-        friend2.accept();
-        friendRepository.save(friend2);
+        Friend friendB1 = Friend.createFriend(user3, user1);
+        friendB1.accept();
+        friendRepository.save(friendB1);
+        Friend friendB2 = Friend.createFriend(user1, user3);
+        friendB2.accept();
+        friendRepository.save(friendB2);
 
-        Friend friend3 = Friend.createFriend(user1, user4);
-        friend3.accept();
-        friendRepository.save(friend3);
+        Friend friendC1 = Friend.createFriend(user1, user4);
+        friendC1.accept();
+        friendRepository.save(friendC1);
+        Friend friendC2 = Friend.createFriend(user4, user1);
+        friendC2.accept();
+        friendRepository.save(friendC2);
 
-        Friend friend4 = Friend.createFriend(user1, user5);
-        friendRepository.save(friend4);
+        Friend friendD1 = Friend.createFriend(user1, user5);
+        friendRepository.save(friendD1);
 
         //when
-        DataListResDto<DefaultUserResDto> result = friendService.getFriendList(user1.getId());
+        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(user1.getId());
 
         //then
-        List<DefaultUserResDto> friendUserList = result.getData();
+        List<ActiveUserResDto> friendUserList = result.getData();
         assertThat(friendUserList.size()).isEqualTo(3);
         assertThat(friendUserList).extracting("userId").containsExactly(user2.getId(), user3.getId(), user4.getId());
     }

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -2,11 +2,13 @@ package houseInception.connet.service;
 
 import houseInception.connet.domain.Friend;
 import houseInception.connet.domain.User;
+import houseInception.connet.domain.UserBlock;
 import houseInception.connet.dto.ActiveUserResDto;
 import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.exception.FriendException;
 import houseInception.connet.repository.FriendRepository;
+import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
@@ -34,6 +36,8 @@ class FriendServiceTest {
     FriendRepository friendRepository;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    UserBlockRepository userBlockRepository;
 
     @Autowired
     EntityManager em;
@@ -75,6 +79,16 @@ class FriendServiceTest {
 
         //then
         assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), WAIT)).isTrue();
+    }
+
+    @Test
+    void requestFriend_차단된_사용자() {
+        //given
+        UserBlock userBlock = UserBlock.create(user1, user2);
+        userBlockRepository.save(userBlock);
+
+        //when
+        assertThatThrownBy(() -> friendService.requestFriend(user1.getId(), user2.getId())).isInstanceOf(FriendException.class);
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -108,12 +108,11 @@ class FriendServiceTest {
         friendRepository.save(friend);
 
         //when
-        Long friendId = friendService.acceptFriendRequest(user2.getId(), user1.getId());
+        friendService.acceptFriendRequest(user2.getId(), user1.getId());
 
         //then
-        Friend findFriend = friendRepository.findById(friendId).orElse(null);
-        assertThat(findFriend).isNotNull();
-        assertThat(findFriend.getAcceptStatus()).isEqualTo(ACCEPT);
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), ACCEPT)).isTrue();
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), ACCEPT)).isTrue();
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
@@ -1,0 +1,49 @@
+package houseInception.connet.service;
+
+import houseInception.connet.domain.User;
+import houseInception.connet.repository.UserBlockRepository;
+import houseInception.connet.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class UserBlockServiceTest {
+
+    @Autowired
+    UserBlockService userBlockService;
+
+    @Autowired
+    UserBlockRepository userBlockRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    User user1;
+    User user2;
+
+    @BeforeEach
+    void beforeEach(){
+        user1 = User.create("user1", null, null, null);
+        userRepository.save(user1);
+
+        user2 = User.create("user2", null, null, null);
+        userRepository.save(user2);
+    }
+
+    @Test
+    void blockUser() {
+        //when
+        userBlockService.blockUser(user1.getId(), user2.getId());
+
+        //then
+        assertThat(userBlockRepository.existsByUserIdAndTargetId(user1.getId(), user2.getId())).isTrue();
+        assertThat(userBlockRepository.existsByUserIdAndTargetId(user2.getId(), user1.getId())).isTrue();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호

- #52 

<br />

## 작업 사항

- 기존 유저 고유 아이디로 친구 요청 로직에 차단된 사용자에게는 요청이 불가능하도록 로직 추가
- 이메일을 통한 친구 요청 기능 개발
- 친구 요청 수락시, 수락한 사용자에서 요청한 사용자로의 친구 관계 형성 로직 추가
- 친구 삭제시 양방향 친구 관계 제거 로직 추가
- 친구 목록 조회에 친구 닉네임을 통한 필터링 기능 추가
- 유저 차단 기능 개발 및 테스트

<br />

## 기타 사항
<br />
