### PR TITLE
친구 요청 취소 및 유저 차단 발생 시 친구 삭제 개발

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -15,7 +15,7 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    @PostMapping("/{targetId}")
+    @PostMapping("/{targetId}/request")
     public BaseResponse<BaseResultDto> requestFriend(@PathVariable Long targetId){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         Long resultId = friendService.requestFriendById(userId, targetId);
@@ -23,7 +23,7 @@ public class FriendController {
         return BaseResponse.getSimpleRes(resultId);
     }
 
-    @PostMapping
+    @PostMapping("/request")
     public BaseResponse<BaseResultDto> requestFriend(@RequestBody @Valid EmailDto emailDto){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         Long resultId = friendService.requestFriendByEmail(userId, emailDto.getEmail());

--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -31,11 +31,11 @@ public class FriendController {
         return BaseResponse.getSimpleRes(resultId);
     }
 
-    @DeleteMapping("/{targetId}")
+    @DeleteMapping("/{targetId}/request")
     public BaseResponse<BaseResultDto> cancelFriendRequest(@PathVariable Long targetId){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         Long resultId = friendService.cancelFriendRequest(userId, targetId);
-        
+
         return BaseResponse.getSimpleRes(resultId);
     }
 

--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -31,6 +31,14 @@ public class FriendController {
         return BaseResponse.getSimpleRes(resultId);
     }
 
+    @DeleteMapping("/{targetId}")
+    public BaseResponse<BaseResultDto> cancelFriendRequest(@PathVariable Long targetId){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        Long resultId = friendService.cancelFriendRequest(userId, targetId);
+        
+        return BaseResponse.getSimpleRes(resultId);
+    }
+
     @PostMapping("/{targetId}/accept")
     public BaseResponse<BaseResultDto> acceptFriendRequest(@PathVariable Long targetId){
         Long userId = UserAuthorizationUtil.getLoginUserId();

--- a/connet/src/main/java/houseInception/connet/dto/EmailDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/EmailDto.java
@@ -4,9 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/connet/src/main/java/houseInception/connet/event/handler/UserBlockEventHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/UserBlockEventHandler.java
@@ -1,0 +1,21 @@
+package houseInception.connet.event.handler;
+
+import houseInception.connet.event.domain.UserBlockEvent;
+import houseInception.connet.service.FriendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class UserBlockEventHandler {
+
+    private final FriendService friendService;
+
+    @Async
+    @TransactionalEventListener
+    public void deleteFriend(UserBlockEvent event){
+        friendService.deleteFriend(event.getUserId(), event.getTargetId());
+    }
+}

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -74,7 +74,7 @@ public class FriendService {
     public Long cancelFriendRequest(Long userId, Long targetId){
         checkExistUser(targetId);
 
-        Friend friend = findFriend(targetId, userId, WAIT);
+        Friend friend = findFriend(userId, targetId, WAIT);
         friendRepository.delete(friend);
 
         return friend.getId();

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -71,6 +71,16 @@ public class FriendService {
     }
 
     @Transactional
+    public Long cancelFriendRequest(Long userId, Long targetId){
+        checkExistUser(targetId);
+
+        Friend friend = findFriend(targetId, userId, WAIT);
+        friendRepository.delete(friend);
+
+        return friend.getId();
+    }
+
+    @Transactional
     public Long acceptFriendRequest(Long userId, Long targetId) {
         User targetUser = findUser(targetId);
         checkHasFriendRequestOfOneWay(targetId, userId);

--- a/connet/src/test/java/houseInception/connet/contoller/FriendControllerTest.java
+++ b/connet/src/test/java/houseInception/connet/contoller/FriendControllerTest.java
@@ -1,0 +1,58 @@
+package houseInception.connet.contoller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import houseInception.connet.dto.EmailDto;
+import houseInception.connet.service.FriendService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FriendControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    FriendController friendController;
+    @InjectMocks
+    FriendService friendService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(friendController)
+                .build();
+    }
+
+    @Test
+    void requestFriend() throws Exception {
+        EmailDto emailDto = new EmailDto("email");
+
+        mockMvc.perform(post("/friends/request")
+                        .content(objectMapper.writeValueAsString(emailDto))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void requestFriend_이메일공백() throws Exception {
+        EmailDto emailDto = new EmailDto(" ");
+
+        mockMvc.perform(post("/friends/request")
+                        .content(objectMapper.writeValueAsString(emailDto))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -129,6 +129,30 @@ class FriendServiceTest {
     }
 
     @Test
+    void cancelFriendRequest() {
+        //given
+        Friend friend = Friend.createFriend(user1, user2);
+        friendRepository.save(friend);
+
+        //when
+        Long resultId = friendService.cancelFriendRequest(user1.getId(), user2.getId());
+
+        //then
+        assertThatThrownBy(() -> friendRepository.findById(resultId).orElseThrow())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void cancelFriendRequest_요청_존재X() {
+        //given
+        Friend friend = Friend.createFriend(user1, user2);
+        friendRepository.save(friend);
+
+        //when
+        assertThatThrownBy(() -> friendService.cancelFriendRequest(user2.getId(), user1.getId())).isInstanceOf(FriendException.class);
+    }
+
+    @Test
     void acceptFriendRequest() {
         //given
         Friend friend = Friend.createFriend(user1, user2);


### PR DESCRIPTION
## 관련 이슈 번호

- #52 

<br />

## 작업 사항

- UserBlockEvent발생 시 존재하는 친구 관계 삭제 로직 개발 및 테스트
- 친구 요청의 url 경로 변경, /request 추가
- 친구 요청 취소 기능 개발 및 테스트

<br />

## 기타 사항
<br />
