### PR TITLE
소켓 연결에 관련된 로직 개발 및 채팅 전송 로직 개발

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
@@ -1,0 +1,25 @@
+package houseInception.connet.contoller;
+
+import houseInception.connet.dto.PrivateChatAddDto;
+import houseInception.connet.dto.PrivateChatAddRestDto;
+import houseInception.connet.response.BaseResponse;
+import houseInception.connet.service.PrivateRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/privateRooms")
+@RequiredArgsConstructor
+@RestController
+public class PrivateRoomController {
+
+    private PrivateRoomService privateRoomService;
+
+    @PostMapping("/{targetId}")
+    public BaseResponse<PrivateChatAddRestDto> addPrivateChat(@PathVariable Long targetId,
+                                                              @ModelAttribute PrivateChatAddDto chatAddDto){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(userId, targetId, chatAddDto);
+
+        return new BaseResponse<>(result);
+    }
+}

--- a/connet/src/main/java/houseInception/connet/domain/User.java
+++ b/connet/src/main/java/houseInception/connet/domain/User.java
@@ -22,6 +22,7 @@ public class User extends BaseTime{
     private String userProfile;
     private String email;
     private String refreshToken;
+    private boolean isActive;
 
     @Enumerated(EnumType.STRING)
     private UserRole role;
@@ -45,5 +46,13 @@ public class User extends BaseTime{
 
     public void deleteRefreshToken(){
         this.refreshToken = null;
+    }
+
+    public void setActive(){
+        isActive = true;
+    }
+
+    public void setInActive(){
+        isActive = false;
     }
 }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static houseInception.connet.domain.ChatterRole.USER;
 import static houseInception.connet.domain.Status.ALIVE;
 
 @Getter
@@ -21,7 +22,7 @@ public class PrivateChat extends BaseTime {
     private Long id;
 
     @JoinColumn(name = "privateRoomId")
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     private PrivateRoom privateRoom;
 
     @JoinColumn(name = "writerId")
@@ -34,8 +35,19 @@ public class PrivateChat extends BaseTime {
     @Enumerated(EnumType.STRING)
     private ChatterRole chatTarget;
 
-    private String content;
+    private String message;
 
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
+
+    protected static PrivateChat createUserToUserChat(PrivateRoom privateRoom, PrivateRoomUser privateRoomUser, String message){
+        PrivateChat privateChat = new PrivateChat();
+        privateChat.privateRoom = privateRoom;
+        privateChat.writer = privateRoomUser;
+        privateChat.writerRole = USER;
+        privateChat.chatTarget = USER;
+        privateChat.message =  message;
+
+        return privateChat;
+    }
 }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -1,0 +1,41 @@
+package houseInception.connet.domain.privateRoom;
+
+import houseInception.connet.domain.BaseTime;
+import houseInception.connet.domain.ChatterRole;
+import houseInception.connet.domain.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static houseInception.connet.domain.Status.ALIVE;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Entity
+public class PrivateChat extends BaseTime {
+
+    @Column(name = "privateChatId")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "privateRoomId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PrivateRoom privateRoom;
+
+    @JoinColumn(name = "writerId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PrivateRoomUser writer;
+
+    @Enumerated(EnumType.STRING)
+    private ChatterRole writerRole;
+
+    @Enumerated(EnumType.STRING)
+    private ChatterRole chatTarget;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private Status status = ALIVE;
+}

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -8,6 +8,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static houseInception.connet.domain.ChatterRole.USER;
 import static houseInception.connet.domain.Status.ALIVE;
 
@@ -36,6 +39,7 @@ public class PrivateChat extends BaseTime {
     private ChatterRole chatTarget;
 
     private String message;
+    private List<String> images = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -2,10 +2,15 @@ package houseInception.connet.domain.privateRoom;
 
 import houseInception.connet.domain.BaseTime;
 import houseInception.connet.domain.Status;
+import houseInception.connet.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
 
@@ -19,6 +24,36 @@ public class PrivateRoom extends BaseTime {
     @Id
     private Long id;
 
+    @OneToMany(mappedBy = "privateRoom", cascade = CascadeType.ALL)
+    private List<PrivateRoomUser> privateRoomUsers = new ArrayList<>();
+
+    private String privateRoomUuid;
+
+    @OneToMany(mappedBy = "privateRoom", cascade = CascadeType.ALL)
+    private List<PrivateChat> privateChats = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
+
+    public static PrivateRoom create(User user, User targetUser){
+        PrivateRoom privateRoom = new PrivateRoom();
+        privateRoom.privateRoomUuid = UUID.randomUUID().toString();
+        privateRoom.privateRoomUsers.add(new PrivateRoomUser(user, privateRoom));
+        privateRoom.privateRoomUsers.add(new PrivateRoomUser(targetUser, privateRoom));
+
+        return privateRoom;
+    }
+
+    public void addUserToUserChat(String message, PrivateRoomUser privateRoomUser){
+        PrivateChat chat = PrivateChat.createUserToUserChat(this, privateRoomUser, message);
+        this.privateChats.add(chat);
+    }
+
+    public List<PrivateChat> getPrivateChats() {
+        return new ArrayList<>(privateChats);
+    }
+
+    public List<PrivateRoomUser> getPrivateRoomUsers() {
+        return new ArrayList<>(privateRoomUsers);
+    }
 }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -44,9 +45,11 @@ public class PrivateRoom extends BaseTime {
         return privateRoom;
     }
 
-    public void addUserToUserChat(String message, PrivateRoomUser privateRoomUser){
+    public PrivateChat addUserToUserChat(String message, PrivateRoomUser privateRoomUser){
         PrivateChat chat = PrivateChat.createUserToUserChat(this, privateRoomUser, message);
         this.privateChats.add(chat);
+
+        return chat;
     }
 
     public List<PrivateChat> getPrivateChats() {
@@ -55,5 +58,12 @@ public class PrivateRoom extends BaseTime {
 
     public List<PrivateRoomUser> getPrivateRoomUsers() {
         return new ArrayList<>(privateRoomUsers);
+    }
+
+    public void setPrivateRoomUserAlive(PrivateRoomUser privateRoomUser, LocalDateTime participationTime){
+        if(privateRoomUser.getPrivateRoom().getId().equals(this.id)){
+            privateRoomUser.setStatus(ALIVE);
+            privateRoomUser.setParticipationTime(participationTime);
+        }
     }
 }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -1,0 +1,24 @@
+package houseInception.connet.domain.privateRoom;
+
+import houseInception.connet.domain.BaseTime;
+import houseInception.connet.domain.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static houseInception.connet.domain.Status.ALIVE;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Entity
+public class PrivateRoom extends BaseTime {
+
+    @Column(name = "privateRoomId")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Status status = ALIVE;
+}

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
@@ -35,4 +35,10 @@ public class PrivateRoomUser extends BaseTime {
 
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
+
+    protected PrivateRoomUser(User user, PrivateRoom privateRoom){
+        this.user = user;
+        this.privateRoom = privateRoom;
+        this.participationTime = LocalDateTime.now();
+    }
 }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
@@ -1,0 +1,38 @@
+package houseInception.connet.domain.privateRoom;
+
+import houseInception.connet.domain.BaseTime;
+import houseInception.connet.domain.Status;
+import houseInception.connet.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static houseInception.connet.domain.Status.ALIVE;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Entity
+public class PrivateRoomUser extends BaseTime {
+
+    @Column(name = "privateRoomUserId")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "privateRoomId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PrivateRoom privateRoom;
+
+    private Long lastReadChatId;
+    private LocalDateTime participationTime;
+
+    @Enumerated(EnumType.STRING)
+    private Status status = ALIVE;
+}

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoomUser.java
@@ -41,4 +41,12 @@ public class PrivateRoomUser extends BaseTime {
         this.privateRoom = privateRoom;
         this.participationTime = LocalDateTime.now();
     }
+
+    protected void setStatus(Status status) {
+        this.status = status;
+    }
+
+    protected void setParticipationTime(LocalDateTime participationTime) {
+        this.participationTime = participationTime;
+    }
 }

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
@@ -1,0 +1,18 @@
+package houseInception.connet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrivateChatAddDto {
+
+    private String chatRoomUuid;
+    private String message;
+    List<MultipartFile> images;
+}

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddRestDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddRestDto.java
@@ -1,0 +1,11 @@
+package houseInception.connet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PrivateChatAddRestDto {
+
+    private String chatRoomUuid;
+}

--- a/connet/src/main/java/houseInception/connet/exception/PrivateRoomException.java
+++ b/connet/src/main/java/houseInception/connet/exception/PrivateRoomException.java
@@ -1,0 +1,14 @@
+package houseInception.connet.exception;
+
+import houseInception.connet.response.status.StatusCode;
+
+public class PrivateRoomException extends BaseException{
+
+    public PrivateRoomException(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public PrivateRoomException(StatusCode status) {
+        this(status, "PrivateRoomException가 발생하였습니다.");
+    }
+}

--- a/connet/src/main/java/houseInception/connet/exception/SocketException.java
+++ b/connet/src/main/java/houseInception/connet/exception/SocketException.java
@@ -1,0 +1,14 @@
+package houseInception.connet.exception;
+
+import houseInception.connet.response.status.StatusCode;
+
+public class SocketException extends BaseException{
+
+    public SocketException(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public SocketException(StatusCode status) {
+        super(status, "SocketException가 발생했습니다.");
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -1,0 +1,15 @@
+package houseInception.connet.repository;
+
+import houseInception.connet.domain.privateRoom.PrivateChat;
+import houseInception.connet.domain.privateRoom.PrivateRoom;
+import houseInception.connet.domain.privateRoom.PrivateRoomUser;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PrivateRoomCustomRepository {
+
+    Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid);
+    Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
+    List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
+}

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package houseInception.connet.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import houseInception.connet.domain.privateRoom.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static houseInception.connet.domain.privateRoom.QPrivateChat.privateChat;
+import static houseInception.connet.domain.privateRoom.QPrivateRoom.privateRoom;
+import static houseInception.connet.domain.privateRoom.QPrivateRoomUser.privateRoomUser;
+
+@RequiredArgsConstructor
+@Repository
+public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomRepository{
+
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid) {
+        PrivateRoom findPrivateRoom = query.selectFrom(privateRoom)
+                .join(privateRoom.privateRoomUsers).fetchJoin()
+                .where(privateRoom.privateRoomUuid.eq(privateRoomUuid))
+                .fetchOne();
+
+        return Optional.ofNullable(findPrivateRoom);
+    }
+
+    @Override
+    public Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId) {
+        PrivateRoomUser findPrivateRoomUser = query.selectFrom(privateRoomUser)
+                .where(privateRoomUser.privateRoom.id.eq(privateRoomId),
+                        privateRoomUser.user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(findPrivateRoomUser);
+    }
+
+    @Override
+    public List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId) {
+        return query.selectFrom(privateChat)
+                .where(privateChat.privateRoom.id.eq(privateRoomId))
+                .fetch();
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomRepository.java
@@ -1,0 +1,12 @@
+package houseInception.connet.repository;
+
+import houseInception.connet.domain.Status;
+import houseInception.connet.domain.privateRoom.PrivateRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PrivateRoomRepository extends JpaRepository<PrivateRoom, Long>, PrivateRoomCustomRepository {
+
+    Optional<PrivateRoom> findByPrivateRoomUuidAndStatus(String privateRoomUuid, Status status);
+}

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -31,7 +31,8 @@ public enum BaseErrorCode implements StatusCode{
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),
 
     //5XX 서버 에러
-    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);
+    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
+    CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);
 
     private int code; //서버 내부 오류 코드
     private String message; //서버 내부 오류 메세지

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -25,6 +25,7 @@ public enum BaseErrorCode implements StatusCode{
     BLOCK_USER(40009, "차단된 유저입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_BLOCK_USER(400010, "이미 차단된 유저입니다.", HttpStatus.BAD_REQUEST),
     NO_SUCH_USER_BLOCK(400011, "차단이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NO_CONTENT_IN_CHAT(400012, "채팅의 내용이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_GOOGLE_TOKEN(40101, "유효하지 않은 Google Access Token입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -1,0 +1,86 @@
+package houseInception.connet.service;
+
+import houseInception.connet.domain.User;
+import houseInception.connet.domain.privateRoom.PrivateRoom;
+import houseInception.connet.domain.privateRoom.PrivateRoomUser;
+import houseInception.connet.dto.PrivateChatAddDto;
+import houseInception.connet.dto.PrivateChatAddRestDto;
+import houseInception.connet.exception.PrivateRoomException;
+import houseInception.connet.exception.UserException;
+import houseInception.connet.repository.PrivateRoomRepository;
+import houseInception.connet.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static houseInception.connet.domain.Status.ALIVE;
+import static houseInception.connet.response.status.BaseErrorCode.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PrivateRoomService {
+
+    private final PrivateRoomRepository privateRoomRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PrivateChatAddRestDto addPrivateChat(Long userId, Long targetId, PrivateChatAddDto chatAddDto) {
+        User targetUser = findUser(targetId);
+        User user = findUser(userId);
+
+        checkValidContent(chatAddDto.getMessage(), chatAddDto.getImages());
+
+        PrivateRoom privateRoom;
+        if (chatAddDto.getChatRoomUuid() == null) {
+            privateRoom = PrivateRoom.create(user, targetUser);
+            privateRoomRepository.save(privateRoom);
+        } else {
+            privateRoom = findPrivateRoom(chatAddDto.getChatRoomUuid());
+        }
+
+        PrivateRoomUser privateRoomUser = findPrivateRoomUser(privateRoom.getId(), userId);
+        if (chatAddDto.getMessage() != null) {
+            privateRoom.addUserToUserChat(chatAddDto.getMessage(), privateRoomUser);
+        }
+
+        //파일일 경우 S3에 저장후 url 공유 로직
+
+        return new PrivateChatAddRestDto(privateRoom.getPrivateRoomUuid());
+    }
+
+    private void checkValidContent(String message, List<MultipartFile> images) {
+        boolean hasMessage = StringUtils.hasText(message);
+        boolean hasImages = images != null && !images.isEmpty();
+
+        if (!hasMessage && !hasImages) {
+            throw new PrivateRoomException(NO_CONTENT_IN_CHAT);
+        }
+    }
+
+
+    private void checkExistUser(Long userId){
+        if (!userRepository.existsByIdAndStatus(userId, ALIVE)){
+            throw new UserException(NO_SUCH_USER);
+        }
+    }
+
+    private User findUser(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(NO_SUCH_USER));
+    }
+
+    private PrivateRoom findPrivateRoom(String privateRoomUuid){
+        return privateRoomRepository.findByPrivateRoomUuidAndStatus(privateRoomUuid, ALIVE)
+                .orElseThrow(() -> new PrivateRoomException(NO_SUCH_CHATROOM));
+    }
+
+    private PrivateRoomUser findPrivateRoomUser(Long privateRoomId, Long userId){
+        return privateRoomRepository.findPrivateRoomUser(privateRoomId, userId)
+                .orElseThrow(() -> new PrivateRoomException(NOT_CHATROOM_USER));
+    }
+}

--- a/connet/src/main/java/houseInception/connet/service/UserService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserService.java
@@ -28,6 +28,18 @@ public class UserService {
         }
     }
 
+    @Transactional
+    public void setUserActive(Long userId){
+        User user = findUser(userId);
+        user.setActive();
+    }
+
+    @Transactional
+    public void setUserInActive(Long userId){
+        User user = findUser(userId);
+        user.setInActive();
+    }
+
     private User findUserByEmail(String email){
         User user = userRepository.findByEmailAndStatus(email, ALIVE).orElse(null);
         if (user == null) {

--- a/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
@@ -24,4 +24,8 @@ public class SocketManager {
 
         return null;
     }
+
+    protected WebSocketSession getSocketSession(Long userId){
+        return userSocketMap.get(userId);
+    }
 }

--- a/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/SocketManager.java
@@ -14,12 +14,14 @@ public class SocketManager {
         userSocketMap.put(userId, session);
     }
 
-    public void deleteSocket(WebSocketSession session){
+    public Long deleteSocket(WebSocketSession session){
         for (Long userId : userSocketMap.keySet()) {
             if(userSocketMap.get(userId).getId().equals(session.getId())){
                 userSocketMap.remove(userId);
-                return;
+                return userId;
             }
         }
+
+        return null;
     }
 }

--- a/connet/src/main/java/houseInception/connet/socketManager/SocketServiceProvider.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/SocketServiceProvider.java
@@ -1,0 +1,37 @@
+package houseInception.connet.socketManager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import houseInception.connet.exception.SocketException;
+import houseInception.connet.socketManager.dto.PrivateChatResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+import static houseInception.connet.response.status.BaseErrorCode.CANT_NOT_PARSE_SOCKET_MESSAGE;
+
+@RequiredArgsConstructor
+@Component
+public class SocketServiceProvider {
+
+    private final SocketManager socketManager;
+    private final ObjectMapper objectMapper;
+
+    public boolean sendMessage(Long userId, PrivateChatResDto privateChatResDto){
+        WebSocketSession socketSession = socketManager.getSocketSession(userId);
+        if (socketSession == null) {
+            return false;
+        }
+
+        try {
+            TextMessage textMessage = new TextMessage(objectMapper.writeValueAsString(privateChatResDto));
+            socketSession.sendMessage(textMessage);
+
+            return true;
+        } catch (IOException e) {
+            throw new SocketException(CANT_NOT_PARSE_SOCKET_MESSAGE);
+        }
+    }
+}

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/ChatMessageType.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/ChatMessageType.java
@@ -1,0 +1,5 @@
+package houseInception.connet.socketManager.dto;
+
+public enum ChatMessageType {
+    PRIVATE, MULTI;
+}

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/ChatterResDto.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/ChatterResDto.java
@@ -1,0 +1,13 @@
+package houseInception.connet.socketManager.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatterResDto {
+
+    private Long userId;
+    private String userName;
+    private String userProfile;
+}

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatResDto.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatResDto.java
@@ -1,0 +1,30 @@
+package houseInception.connet.socketManager.dto;
+
+import houseInception.connet.domain.ChatterRole;
+import houseInception.connet.domain.User;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static houseInception.connet.socketManager.dto.ChatMessageType.PRIVATE;
+
+@Getter
+public class PrivateChatResDto {
+
+    private ChatMessageType type = PRIVATE;
+    private String chatRoomUuid;
+    private String message;
+    private List<String> images;
+    private ChatterRole writerRole;
+    private ChatterResDto writer;
+    private LocalDateTime createAt;
+
+    public PrivateChatResDto(String chatRoomUuid, String message, List<String> images, ChatterRole writerRole, User user, LocalDateTime createAt) {
+        this.message = message;
+        this.images = images;
+        this.writerRole = writerRole;
+        this.writer = new ChatterResDto(user.getId(), user.getUserName(), user.getUserProfile());
+        this.createAt = createAt;
+    }
+}

--- a/connet/src/main/java/houseInception/socket/SocketHandler.java
+++ b/connet/src/main/java/houseInception/socket/SocketHandler.java
@@ -1,5 +1,6 @@
 package houseInception.socket;
 
+import houseInception.connet.service.UserService;
 import houseInception.connet.socketManager.SocketManager;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class SocketHandler extends TextWebSocketHandler {
 
     private final SocketManager socketManager;
+    private final UserService userService;
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
@@ -25,14 +27,18 @@ public class SocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         super.afterConnectionEstablished(session);
 
-        String userId = MDC.get("socketUserId");
-        socketManager.addSocket(Long.parseLong(userId), session);
+        Long userId = Long.parseLong(MDC.get("socketUserId"));
+        socketManager.addSocket(userId, session);
+        userService.setUserActive(userId);
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        socketManager.deleteSocket(session);
-
+        Long userId = socketManager.deleteSocket(session);
+        if(userId != null){
+            userService.setUserInActive(userId);
+        }
+        
         super.afterConnectionClosed(session, status);
     }
 }

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -1,0 +1,96 @@
+package houseInception.connet.service;
+
+import houseInception.connet.domain.Status;
+import houseInception.connet.domain.User;
+import houseInception.connet.domain.privateRoom.PrivateChat;
+import houseInception.connet.domain.privateRoom.PrivateRoom;
+import houseInception.connet.domain.privateRoom.PrivateRoomUser;
+import houseInception.connet.dto.PrivateChatAddDto;
+import houseInception.connet.dto.PrivateChatAddRestDto;
+import houseInception.connet.repository.PrivateRoomRepository;
+import houseInception.connet.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static houseInception.connet.domain.Status.ALIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+class PrivateRoomServiceTest {
+
+    @Autowired
+    PrivateRoomService privateRoomService;
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PrivateRoomRepository privateRoomRepository;
+
+    @Autowired
+    EntityManager em;
+
+    User user1;
+    User user2;
+    User user3;
+
+    @BeforeEach
+    void beforeEach(){
+        user1 = User.create("user1", null, null, null);
+        userRepository.save(user1);
+
+        user2 = User.create("user2", null, null, null);
+        userRepository.save(user2);
+
+        user3 = User.create("user3", null, null, null);
+        userRepository.save(user3);
+    }
+
+    @Test
+    void addPrivateChat_채팅방X_파일X() {
+        //when
+        String message = "mess1";
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
+        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
+
+        //then
+        PrivateRoom privateRoom = privateRoomRepository.findPrivateRoomWithUser(result.getChatRoomUuid()).orElse(null);
+        assertThat(privateRoom).isNotNull();
+
+        List<PrivateRoomUser> privateRoomUsers = privateRoom.getPrivateRoomUsers();
+        assertThat(privateRoomUsers.size()).isEqualTo(2);
+        assertThat(privateRoomUsers.stream().map(PrivateRoomUser::getUser))
+                .extracting("id").contains(user1.getId(), user2.getId());
+
+        List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());
+        assertThat(privateChats.size()).isEqualTo(1);
+        assertThat(privateChats.get(0).getMessage()).isEqualTo(message);
+    }
+
+    @Test
+    void addPrivateChat_채팅방O_파일X() {
+        //given
+        PrivateRoom privateRoom = PrivateRoom.create(user1, user2);
+        privateRoomRepository.save(privateRoom);
+
+        //when
+        String message = "mess1";
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(privateRoom.getPrivateRoomUuid(), message, null);
+        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
+
+        //then
+        List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());
+        assertThat(privateChats.size()).isEqualTo(1);
+        assertThat(privateChats.get(0).getMessage()).isEqualTo(message);
+    }
+}

--- a/connet/src/test/resources/application.yml
+++ b/connet/src/test/resources/application.yml
@@ -11,8 +11,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         default_batch_fetch_size: 100
-#        show_sql: true   # 하이버네이트 기본 SQL 출력 옵션
-#        format_sql: true # 하이버네이트 기본 SQL 포맷팅 옵션
+        show_sql: true   # 하이버네이트 기본 SQL 출력 옵션
+        format_sql: true # 하이버네이트 기본 SQL 포맷팅 옵션
 
 jwt:
   secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 관련 이슈 번호

- #50 

<br />

## 작업 사항

- 클라이언트가 소켓 연결 시 유저의 활성화 로직 개발
- 클라이언트의 소켓 연결 종료 시 유저의 비활성화 로직 개발
- 사용자의 소켓 관리(추가, 삭제)를 위한 SocketManager클래스 개발
- 소켓에 메세지 전송을 위한 서비스 로직을 제공하는 SocketServiceProvider 개발
- 개인 채팅 전송 로직 개발
아직 유저 차단 규칙, 이미지, 파일 저장을 위한 S3연결 미고려.

<br />

## 기타 사항
다른 서비스에서 채팅을 소켓에 전송하기 위해 SocketManager에 접근하는 것은 소켓을 추가하고 삭제하는 메서드에 접근할 수 있는 위험성이 있기 때문에 명확한 책임 구분을 위한 SocketServiceProvider 분리
<br />
