### PR TITLE
개인 채팅 전송에 S3를 통한 이미지 전송 지원, 차단된 유저는 오류 처리 로직 개발

### DIFF
--- a/connet/build.gradle
+++ b/connet/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
 	testImplementation 'org.mockito:mockito-core:4.0.0'
 	testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
+
+	//s3
+	implementation 'software.amazon.awssdk:s3:2.29.15'
 }
 
 tasks.named('test') {

--- a/connet/src/main/java/houseInception/connet/ConnetConfig.java
+++ b/connet/src/main/java/houseInception/connet/ConnetConfig.java
@@ -2,9 +2,15 @@ package houseInception.connet;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 
 @Configuration
 public class ConnetConfig {

--- a/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class PrivateRoomController {
 
-    private PrivateRoomService privateRoomService;
+    private final PrivateRoomService privateRoomService;
 
     @PostMapping("/{targetId}")
     public BaseResponse<PrivateChatAddRestDto> addPrivateChat(@PathVariable Long targetId,

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -39,18 +39,20 @@ public class PrivateChat extends BaseTime {
     private ChatterRole chatTarget;
 
     private String message;
-    private List<String> images = new ArrayList<>();
+    private String image;
 
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
 
-    protected static PrivateChat createUserToUserChat(PrivateRoom privateRoom, PrivateRoomUser privateRoomUser, String message){
+    protected static PrivateChat createUserToUserChat
+            (PrivateRoom privateRoom, PrivateRoomUser privateRoomUser, String message, String imgUrl){
         PrivateChat privateChat = new PrivateChat();
         privateChat.privateRoom = privateRoom;
         privateChat.writer = privateRoomUser;
         privateChat.writerRole = USER;
         privateChat.chatTarget = USER;
         privateChat.message =  message;
+        privateChat.image = imgUrl;
 
         return privateChat;
     }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -33,6 +33,7 @@ public class PrivateRoom extends BaseTime {
     @OneToMany(mappedBy = "privateRoom", cascade = CascadeType.ALL)
     private List<PrivateChat> privateChats = new ArrayList<>();
 
+
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
 
@@ -45,8 +46,8 @@ public class PrivateRoom extends BaseTime {
         return privateRoom;
     }
 
-    public PrivateChat addUserToUserChat(String message, PrivateRoomUser privateRoomUser){
-        PrivateChat chat = PrivateChat.createUserToUserChat(this, privateRoomUser, message);
+    public PrivateChat addUserToUserChat(String message, String imgUrl, PrivateRoomUser privateRoomUser){
+        PrivateChat chat = PrivateChat.createUserToUserChat(this, privateRoomUser, message, imgUrl);
         this.privateChats.add(chat);
 
         return chat;

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
@@ -3,10 +3,12 @@ package houseInception.connet.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,5 +16,5 @@ public class PrivateChatAddDto {
 
     private String chatRoomUuid;
     private String message;
-    List<MultipartFile> images;
+    private MultipartFile image;
 }

--- a/connet/src/main/java/houseInception/connet/exception/S3UploadException.java
+++ b/connet/src/main/java/houseInception/connet/exception/S3UploadException.java
@@ -1,0 +1,14 @@
+package houseInception.connet.exception;
+
+import houseInception.connet.response.status.StatusCode;
+
+public class S3UploadException extends BaseException{
+
+    public S3UploadException(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public S3UploadException(StatusCode status) {
+        super(status, "S3UploadException가 발생했습니다.");
+    }
+}

--- a/connet/src/main/java/houseInception/connet/externalServiceProvider/s3/AwsConfig.java
+++ b/connet/src/main/java/houseInception/connet/externalServiceProvider/s3/AwsConfig.java
@@ -1,0 +1,32 @@
+package houseInception.connet.externalServiceProvider.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${aws.s3.accessKeyId}")
+    private String accessKeyId;
+    @Value("${aws.s3.secretAccessKey}")
+    private String secretAccessKey;
+
+    @Bean
+    public S3Client s3Client(){
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .serviceConfiguration(S3Configuration.builder()
+                        .checksumValidationEnabled(false)
+                        .build())
+                .build();
+    }
+}

--- a/connet/src/main/java/houseInception/connet/externalServiceProvider/s3/S3ServiceProvider.java
+++ b/connet/src/main/java/houseInception/connet/externalServiceProvider/s3/S3ServiceProvider.java
@@ -1,0 +1,44 @@
+package houseInception.connet.externalServiceProvider.s3;
+
+import houseInception.connet.exception.S3UploadException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+
+import static houseInception.connet.response.status.BaseErrorCode.CAN_NOT_UPLOAD_FILE_TO_S3;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3ServiceProvider {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucketName}")
+    private String bucketName;
+
+    public void uploadImage(String objectKey, MultipartFile file){
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .build();
+            s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (S3Exception e) {
+            log.error("S3Exception ", e);
+            throw new S3UploadException(CAN_NOT_UPLOAD_FILE_TO_S3);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -26,13 +26,15 @@ public enum BaseErrorCode implements StatusCode{
     ALREADY_BLOCK_USER(400010, "이미 차단된 유저입니다.", HttpStatus.BAD_REQUEST),
     NO_SUCH_USER_BLOCK(400011, "차단이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     NO_CONTENT_IN_CHAT(400012, "채팅의 내용이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NO_VALID_FILE_NAME(400013, "파일 이름이 옳바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_GOOGLE_TOKEN(40101, "유효하지 않은 Google Access Token입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),
 
     //5XX 서버 에러
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
-    CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);
+    CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
+    CAN_NOT_UPLOAD_FILE_TO_S3(50002, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);
 
     private int code; //서버 내부 오류 코드
     private String message; //서버 내부 오류 메세지

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -11,6 +11,7 @@ import houseInception.connet.exception.PrivateRoomException;
 import houseInception.connet.exception.UserException;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.PrivateRoomRepository;
+import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
 import houseInception.connet.socketManager.SocketServiceProvider;
 import houseInception.connet.socketManager.dto.PrivateChatResDto;
@@ -38,6 +39,7 @@ public class PrivateRoomService {
     private final SocketServiceProvider socketServiceProvider;
     private final S3ServiceProvider s3ServiceProvider;
     private final PrivateRoomRepository privateRoomRepository;
+    private final UserBlockRepository userBlockRepository;
     private final UserRepository userRepository;
     private final EntityManager em;
 
@@ -49,6 +51,7 @@ public class PrivateRoomService {
         User targetUser = findUser(targetId);
         User user = findUser(userId);
 
+        checkHasUserBlock(userId, targetId);
         checkValidContent(chatAddDto.getMessage(), chatAddDto.getImage());
 
         PrivateRoom privateRoom;
@@ -113,6 +116,12 @@ public class PrivateRoomService {
     private void checkExistUser(Long userId){
         if (!userRepository.existsByIdAndStatus(userId, ALIVE)){
             throw new UserException(NO_SUCH_USER);
+        }
+    }
+
+    private void checkHasUserBlock(Long userId, Long targetId) {
+        if(userBlockRepository.existsByUserIdAndTargetId(userId, targetId)){
+            throw new PrivateRoomException(BLOCK_USER);
         }
     }
 

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -9,18 +9,22 @@ import houseInception.connet.dto.PrivateChatAddDto;
 import houseInception.connet.dto.PrivateChatAddRestDto;
 import houseInception.connet.exception.PrivateRoomException;
 import houseInception.connet.exception.UserException;
+import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.PrivateRoomRepository;
 import houseInception.connet.repository.UserRepository;
 import houseInception.connet.socketManager.SocketServiceProvider;
 import houseInception.connet.socketManager.dto.PrivateChatResDto;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
@@ -32,19 +36,23 @@ import static houseInception.connet.response.status.BaseErrorCode.*;
 public class PrivateRoomService {
 
     private final SocketServiceProvider socketServiceProvider;
+    private final S3ServiceProvider s3ServiceProvider;
     private final PrivateRoomRepository privateRoomRepository;
     private final UserRepository userRepository;
     private final EntityManager em;
+
+    @Value("${aws.s3.imageUrlPrefix}")
+    private String s3UrlPrefix;
 
     @Transactional
     public PrivateChatAddRestDto addPrivateChat(Long userId, Long targetId, PrivateChatAddDto chatAddDto) {
         User targetUser = findUser(targetId);
         User user = findUser(userId);
 
-        checkValidContent(chatAddDto.getMessage(), chatAddDto.getImages());
+        checkValidContent(chatAddDto.getMessage(), chatAddDto.getImage());
 
         PrivateRoom privateRoom;
-        if (chatAddDto.getChatRoomUuid() == null) {
+        if (chatAddDto.getChatRoomUuid() == null || chatAddDto.getChatRoomUuid().isBlank()) {
             privateRoom = PrivateRoom.create(user, targetUser);
             privateRoomRepository.save(privateRoom);
         } else {
@@ -53,8 +61,9 @@ public class PrivateRoomService {
 
         PrivateRoomUser privateRoomSender = findPrivateRoomUser(privateRoom.getId(), userId);
 
-        //파일일 경우 S3에 저장후 url 공유 로직
-        PrivateChat privateChat = privateRoom.addUserToUserChat(chatAddDto.getMessage(), privateRoomSender);
+        String imgUrl = uploadImages(chatAddDto.getImage());
+
+        PrivateChat privateChat = privateRoom.addUserToUserChat(chatAddDto.getMessage(), imgUrl, privateRoomSender);
         em.flush();
 
         PrivateRoomUser privateRoomReceiver = findPrivateRoomUser(privateRoom.getId(), targetId);
@@ -63,15 +72,37 @@ public class PrivateRoomService {
         }
 
         PrivateChatResDto privateChatResDto =
-                new PrivateChatResDto(privateRoom.getPrivateRoomUuid(), chatAddDto.getMessage(), null, ChatterRole.USER, user, privateChat.getCreatedAt());
+                new PrivateChatResDto(privateRoom.getPrivateRoomUuid(), chatAddDto.getMessage(), imgUrl, ChatterRole.USER, user, privateChat.getCreatedAt());
         socketServiceProvider.sendMessage(targetId, privateChatResDto);
 
         return new PrivateChatAddRestDto(privateRoom.getPrivateRoomUuid());
     }
 
-    private void checkValidContent(String message, List<MultipartFile> images) {
+    private String uploadImages(MultipartFile image){
+        if (image == null) {
+            return null;
+        }
+
+        String newFileName = getUniqueFileName(image.getOriginalFilename());
+        s3ServiceProvider.uploadImage(newFileName, image);
+
+        return s3UrlPrefix + newFileName;
+    }
+
+    private String getUniqueFileName(String originalFileName){
+        int extensionIndex = originalFileName.lastIndexOf(".");
+        if(extensionIndex == -1){
+            throw new PrivateRoomException(NO_VALID_FILE_NAME);
+        }
+
+        String extension = originalFileName.substring(extensionIndex);
+
+        return UUID.randomUUID() + extension;
+    }
+
+    private void checkValidContent(String message, MultipartFile images) {
         boolean hasMessage = StringUtils.hasText(message);
-        boolean hasImages = images != null && !images.isEmpty();
+        boolean hasImages = images != null;
 
         if (!hasMessage && !hasImages) {
             throw new PrivateRoomException(NO_CONTENT_IN_CHAT);

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatResDto.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatResDto.java
@@ -15,14 +15,14 @@ public class PrivateChatResDto {
     private ChatMessageType type = PRIVATE;
     private String chatRoomUuid;
     private String message;
-    private List<String> images;
+    private String image;
     private ChatterRole writerRole;
     private ChatterResDto writer;
     private LocalDateTime createAt;
 
-    public PrivateChatResDto(String chatRoomUuid, String message, List<String> images, ChatterRole writerRole, User user, LocalDateTime createAt) {
+    public PrivateChatResDto(String chatRoomUuid, String message, String image, ChatterRole writerRole, User user, LocalDateTime createAt) {
         this.message = message;
-        this.images = images;
+        this.image = image;
         this.writerRole = writerRole;
         this.writer = new ChatterResDto(user.getId(), user.getUserName(), user.getUserProfile());
         this.createAt = createAt;

--- a/connet/src/main/resources/application.yml
+++ b/connet/src/main/resources/application.yml
@@ -25,6 +25,13 @@ google:
   id: ${GOOGLE_CLIENT_ID}
   password: ${GOOGLE_CLIENT_SECRET}
 
+aws:
+  s3:
+    accessKeyId : ${AWS_ACCESS_KEY_ID}
+    secretAccessKey : ${AWS_SECRET_ACCESS_KEY}
+    bucketName : ${AWS_S3_BUCKET_NAME}
+    imageUrlPrefix : ${AWS_S3_URL_PREFIX}
+
 logging:
   pattern:
     console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ, Asia/Seoul} [%X{request_id}] %-5level [%thread] %logger{36} - %msg%n"

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -1,17 +1,19 @@
 package houseInception.connet.service;
 
-import houseInception.connet.domain.Status;
 import houseInception.connet.domain.User;
+import houseInception.connet.domain.UserBlock;
+import houseInception.connet.domain.UserBlockType;
 import houseInception.connet.domain.privateRoom.PrivateChat;
 import houseInception.connet.domain.privateRoom.PrivateRoom;
 import houseInception.connet.domain.privateRoom.PrivateRoomUser;
 import houseInception.connet.dto.PrivateChatAddDto;
 import houseInception.connet.dto.PrivateChatAddRestDto;
+import houseInception.connet.exception.PrivateRoomException;
 import houseInception.connet.repository.PrivateRoomRepository;
+import houseInception.connet.repository.UserBlockRepository;
 import houseInception.connet.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static houseInception.connet.domain.Status.ALIVE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -36,6 +38,8 @@ class PrivateRoomServiceTest {
     UserRepository userRepository;
     @Autowired
     PrivateRoomRepository privateRoomRepository;
+    @Autowired
+    UserBlockRepository userBlockRepository;
 
     @Autowired
     EntityManager em;
@@ -92,5 +96,20 @@ class PrivateRoomServiceTest {
         List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());
         assertThat(privateChats.size()).isEqualTo(1);
         assertThat(privateChats.get(0).getMessage()).isEqualTo(message);
+    }
+
+    @Test
+    void addPrivateChat_차단된_유저() {
+        //given
+        UserBlock userBlock = UserBlock.create(user2, user1, UserBlockType.REQUEST);
+        userBlockRepository.save(userBlock);
+
+        UserBlock reverseUserBlock = UserBlock.create(user1, user2, UserBlockType.ACCEPT);
+        userBlockRepository.save(reverseUserBlock);
+
+        //when
+        String message = "mess1";
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
+        assertThatThrownBy(() -> privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto)).isInstanceOf(PrivateRoomException.class);
     }
 }

--- a/connet/src/test/resources/application.yml
+++ b/connet/src/test/resources/application.yml
@@ -11,8 +11,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         default_batch_fetch_size: 100
-        show_sql: true   # 하이버네이트 기본 SQL 출력 옵션
-        format_sql: true # 하이버네이트 기본 SQL 포맷팅 옵션
+#        show_sql: true   # 하이버네이트 기본 SQL 출력 옵션
+#        format_sql: true # 하이버네이트 기본 SQL 포맷팅 옵션
 
 jwt:
   secret: ${JWT_SECRET_KEY}
@@ -25,7 +25,16 @@ google:
   id: ${GOOGLE_CLIENT_ID}
   password: ${GOOGLE_CLIENT_SECRET}
 
+aws:
+  s3:
+    accessKeyId : ${AWS_ACCESS_KEY_ID}
+    secretAccessKey : ${AWS_SECRET_ACCESS_KEY}
+    bucketName : ${AWS_S3_BUCKET_NAME}
+    imageUrlPrefix : ${AWS_S3_URL_PREFIX}
+
 logging:
+  pattern:
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ, Asia/Seoul} [%X{request_id}] %-5level [%thread] %logger{36} - %msg%n"
   level:
     root: INFO
   file:


### PR DESCRIPTION
## 관련 이슈 번호

- #59 

<br />

## 작업 사항

- S3 연결 및 설정
- 이미지가 존재한다면 S3에 업로드 후 url 반환 로직 개발
- 전송자와 수신자 둘 사이에 차단 관계가 존재한다면 채팅 전송 금지 처리 

<br />

## 기타 사항
기획적인 부분, 프론트 개발 부분에서 하나의 채팅에 사진이 몇개까지 첨부될지 모호해 단일 이미지만 첨부가 가능하게끔 구현함
<br />
