### PR TITLE
EventFriendHandler 에서 트랜잭션이 유지되어 commit되지 않는 문제를 @Async로 해결

### DIFF
--- a/connet/src/main/java/houseInception/connet/ConnetApplication.java
+++ b/connet/src/main/java/houseInception/connet/ConnetApplication.java
@@ -3,7 +3,9 @@ package houseInception.connet;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class ConnetApplication {

--- a/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -18,8 +20,8 @@ public class EventFriendHandler {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteFriend(UserBlockEvent event){
-        log.info("이벤트핸들러!");
         friendService.deleteFriend(event.getUserId(), event.getTargetId());
     }
 }

--- a/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
@@ -3,19 +3,23 @@ package houseInception.connet.event.handler;
 import houseInception.connet.event.domain.UserBlockEvent;
 import houseInception.connet.service.FriendService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
-public class UserBlockEventHandler {
+public class EventFriendHandler {
 
     private final FriendService friendService;
 
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFriend(UserBlockEvent event){
+        log.info("이벤트핸들러!");
         friendService.deleteFriend(event.getUserId(), event.getTargetId());
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -164,29 +164,17 @@ public class FriendService {
     }
 
     private User findUser(Long userId){
-        User user = userRepository.findById(userId).orElse(null);
-        if (user == null) {
-            throw new UserException(NO_SUCH_USER);
-        }
-
-        return user;
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(NO_SUCH_USER));
     }
 
     private User findUserByEmail(String email){
-        User user = userRepository.findByEmailAndStatus(email, ALIVE).orElse(null);
-        if (user == null) {
-            throw new UserException(NO_SUCH_USER);
-        }
-
-        return user;
+        return userRepository.findByEmailAndStatus(email, ALIVE)
+                .orElseThrow(() -> new UserException(NO_SUCH_USER));
     }
 
     private Friend findFriend(Long senderId, Long receiverId, FriendStatus acceptStatus){
-        Friend friend = friendRepository.findBySenderIdAndReceiverIdAndAcceptStatus(senderId, receiverId, acceptStatus).orElse(null);
-        if(friend == null){
-            throw new FriendException(NO_SUCH_FRIEND);
-        }
-
-        return friend;
+        return friendRepository.findBySenderIdAndReceiverIdAndAcceptStatus(senderId, receiverId, acceptStatus)
+                .orElseThrow(() -> new FriendException(NO_SUCH_FRIEND));
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호

- #73 

<br />

## 작업 사항

- EventFriendHandler 에서 트랜잭션이 유지되어 commit되지 않는 문제를 @Async로 해결

<br />

## 기타 사항
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)는 이전 트랜잭션이 커밋된 이후에 실행되지만 database connection을 반납하지 않고 홀딩하고 있음. 따라서 handler에서 실행되는 Transaction은 트랜잭션 전파가 되고, 이미 commit되었기 때문에 commit되지 않음. 따라서 트랜잭션을 분리하여야 함.
방법은 두가지. 1.@Async로 별도의 스레드에서 실행하면 트랜잭션 분리. 2.@Transactional(propagation = Propagation.REQUIRES_NEW)로 트랜잭션을 전파하지 않고 새로운 트랜잭션 생성
<br />
