### PR TITLE
개인 채팅을 위한 소켓 연결 오류 개선

### DIFF
--- a/connet/src/main/java/houseInception/connet/socket/SocketConfig.java
+++ b/connet/src/main/java/houseInception/connet/socket/SocketConfig.java
@@ -1,11 +1,13 @@
-package houseInception.socket;
+package houseInception.connet.socket;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
 @RequiredArgsConstructor
+@EnableWebSocket
 @Configuration
 public class SocketConfig implements WebSocketConfigurer {
 
@@ -14,7 +16,7 @@ public class SocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(socketHandler, "/socket")
+        registry.addHandler(socketHandler, "/connetSocket")
                 .setAllowedOrigins("*")
                 .addInterceptors(authHandshakeInterceptor);
     }

--- a/connet/src/main/java/houseInception/connet/socket/SocketHandler.java
+++ b/connet/src/main/java/houseInception/connet/socket/SocketHandler.java
@@ -1,4 +1,4 @@
-package houseInception.socket;
+package houseInception.connet.socket;
 
 import houseInception.connet.service.UserService;
 import houseInception.connet.socketManager.SocketManager;
@@ -27,7 +27,7 @@ public class SocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         super.afterConnectionEstablished(session);
 
-        Long userId = Long.parseLong(MDC.get("socketUserId"));
+        Long userId = (Long) session.getAttributes().get("Socket-User-Id");
         socketManager.addSocket(userId, session);
         userService.setUserActive(userId);
     }

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatSocketDto.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatSocketDto.java
@@ -20,6 +20,7 @@ public class PrivateChatSocketDto {
     private LocalDateTime createAt;
 
     public PrivateChatSocketDto(String chatRoomUuid, String message, String image, ChatterRole writerRole, User user, LocalDateTime createAt) {
+        this.chatRoomUuid = chatRoomUuid;
         this.message = message;
         this.image = image;
         this.writerRole = writerRole;


### PR DESCRIPTION
## 관련 이슈 번호

- #59 

<br />

## 작업 사항

- SocketConfig의 패키지 위치가 잘못되어 컴포넌트 스캔이 되지 않는 문제 해결, @EnableWebSocket를 추가하지 않아 registerWebSocketHandlers가 호출되지 않는 문제 해결
- WebSocket은 핸드셰이크 과정에서 HTTP를 사용하기 때문에 Spring Security의 filter가 적용됨. 따라서 중복 구현하였던 핸드셰이크 Interceptor 개선
- PrivateChatSocketDto에서 chatRoomUuid가 초기화 되지 않아 null값이 응답 가는 문제 해결

<br />

## 기타 사항
포스트맨에서 소켓 연결 확인 완료함
<br />
