### PR TITLE
소켓 연결시 토큰을 받는 방식 변경

### DIFF
--- a/connet/src/main/java/houseInception/connet/filter/security/SpringConfig.java
+++ b/connet/src/main/java/houseInception/connet/filter/security/SpringConfig.java
@@ -31,6 +31,7 @@ public class SpringConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(POST, "/login/sign-in").permitAll()
                         .requestMatchers(POST, "/refresh/check").permitAll()
+                        .requestMatchers("/connetSocket").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(mdcFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/connet/src/main/java/houseInception/connet/socket/AuthHandshakeInterceptor.java
+++ b/connet/src/main/java/houseInception/connet/socket/AuthHandshakeInterceptor.java
@@ -5,14 +5,16 @@ import houseInception.connet.domain.User;
 import houseInception.connet.jwt.JwtTokenProvider;
 import houseInception.connet.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.MDC;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -24,17 +26,32 @@ public class AuthHandshakeInterceptor implements HandshakeInterceptor {
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
-        String token = getToken(request.getHeaders());
+        String token = getToken(request.getURI());
+        String userEmail = checkValidToken(token);
 
-        String userEmail = tokenProvider.getUserPk(token);
+        if (userEmail == null) {
+            return false;
+        }
+
         User user = userRepository.findByEmailAndStatus(userEmail, Status.ALIVE).orElseThrow();
-
         attributes.put("Socket-User-Id", user.getId());
+
         return true;
     }
 
-    private String getToken(HttpHeaders headers){
-        return headers.getFirst("Authorization").substring(7);
+    private String  checkValidToken(String token){
+        if(token != null && tokenProvider.validateToken(token)){
+            return tokenProvider.getUserPk(token);
+        }
+
+        return null;
+    }
+
+    private String getToken(URI uri){
+        return UriComponentsBuilder.fromUri(uri)
+                .build()
+                .getQueryParams()
+                .getFirst("token");
     }
 
     @Override


### PR DESCRIPTION
## 관련 이슈 번호

- #59 

<br />

## 작업 사항

- 기존에는 소켓을 연결할때 유저 검증 토큰을 헤더로 받았었지만 쿼리 파라미터로 수정

<br />

## 기타 사항

- Js에서는 Websocket연결시 헤더 수정 불가능. 따라서 쿼리 파라미터를 통해 검증을 진행함. 후에 https로 변경을 통해 암호화 처리가 필요할걸로 보임

<br />
