### PR TITLE
개인 채팅방에서 gpt 채팅 전송 기능 구현

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
@@ -15,10 +15,19 @@ public class PrivateRoomController {
     private final PrivateRoomService privateRoomService;
 
     @PostMapping("/{targetId}")
-    public BaseResponse<PrivateChatAddRestDto> addPrivateChat(@PathVariable Long targetId,
-                                                              @ModelAttribute PrivateChatAddDto chatAddDto){
+    public BaseResponse<PrivateChatAddResDto> addPrivateChat(@PathVariable Long targetId,
+                                                             @ModelAttribute PrivateChatAddDto chatAddDto){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(userId, targetId, chatAddDto);
+        PrivateChatAddResDto result = privateRoomService.addPrivateChat(userId, targetId, chatAddDto);
+
+        return new BaseResponse<>(result);
+    }
+
+    @PostMapping("/{privateRoomUuid}/gpt")
+    public BaseResponse<GptPrivateChatAddResDto> addGptChat(@PathVariable String privateRoomUuid,
+                                                            @RequestBody PrivateGptChatAddDto gptChatAddDto){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        GptPrivateChatAddResDto result = privateRoomService.addGptChat(userId, privateRoomUuid, gptChatAddDto.getMessage());
 
         return new BaseResponse<>(result);
     }
@@ -40,7 +49,8 @@ public class PrivateRoomController {
     }
 
     @GetMapping("/{privateRoomUuid}/chats")
-    public BaseResponse<DataListResDto<PrivateChatResDto>> getPrivateChatList(@PathVariable String privateRoomUuid, @RequestParam(defaultValue = "1") int page){
+    public BaseResponse<DataListResDto<PrivateChatResDto>> getPrivateChatList(@PathVariable String privateRoomUuid,
+                                                                              @RequestParam(defaultValue = "1") int page){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         DataListResDto<PrivateChatResDto> result = privateRoomService.getPrivateChatList(userId, privateRoomUuid, page);
 

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import static houseInception.connet.domain.ChatterRole.GPT;
 import static houseInception.connet.domain.ChatterRole.USER;
 import static houseInception.connet.domain.Status.ALIVE;
 
@@ -53,6 +54,27 @@ public class PrivateChat extends BaseTime {
         privateChat.chatTarget = USER;
         privateChat.message =  message;
         privateChat.image = imgUrl;
+
+        return privateChat;
+    }
+
+    protected static PrivateChat createUserToGptChat(PrivateRoom privateRoom, PrivateRoomUser privateRoomUser, String message) {
+        PrivateChat privateChat = new PrivateChat();
+        privateChat.privateRoom = privateRoom;
+        privateChat.writer = privateRoomUser;
+        privateChat.writerRole = USER;
+        privateChat.chatTarget = GPT;
+        privateChat.message =  message;
+
+        return privateChat;
+    }
+
+    protected static PrivateChat createGptToUserChat(PrivateRoom privateRoom, String message) {
+        PrivateChat privateChat = new PrivateChat();
+        privateChat.privateRoom = privateRoom;
+        privateChat.writerRole = GPT;
+        privateChat.chatTarget = USER;
+        privateChat.message =  message;
 
         return privateChat;
     }

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -39,6 +39,7 @@ public class PrivateChat extends BaseTime {
     @Enumerated(EnumType.STRING)
     private ChatterRole chatTarget;
 
+    @Lob
     private String message;
     private String image;
 

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
-import static houseInception.connet.domain.privateRoom.QPrivateRoomUser.privateRoomUser;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PACKAGE)

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateRoom.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
+import static houseInception.connet.domain.privateRoom.QPrivateRoomUser.privateRoomUser;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
@@ -55,6 +56,24 @@ public class PrivateRoom extends BaseTime {
         }
 
         return null;
+    }
+
+    public PrivateChat addUserToGptChat(String message, PrivateRoomUser privateRoomUser) {
+        if (privateRoomUser.getPrivateRoom().getId().equals(this.id)) {
+            PrivateChat chat = PrivateChat.createUserToGptChat(this, privateRoomUser, message);
+            this.privateChats.add(chat);
+
+            return chat;
+        }
+
+        return null;
+    }
+
+    public PrivateChat addGptToUserChat(String message) {
+        PrivateChat chat = PrivateChat.createGptToUserChat(this, message);
+        this.privateChats.add(chat);
+
+        return chat;
     }
 
     public List<PrivateChat> getPrivateChats() {

--- a/connet/src/main/java/houseInception/connet/dto/GptPrivateChatAddResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/GptPrivateChatAddResDto.java
@@ -1,0 +1,17 @@
+package houseInception.connet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class GptPrivateChatAddResDto {
+
+    private Long userChatId;
+    private LocalDateTime userChatCreateAt;
+    private Long gptChatId;
+    private LocalDateTime gptChatCreateAt;
+    private String message;
+}

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
@@ -1,9 +1,6 @@
 package houseInception.connet.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -11,7 +8,7 @@ import java.util.List;
 @Setter
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PrivateChatAddDto {
 
     private String chatRoomUuid;

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddResDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class PrivateChatAddRestDto {
+public class PrivateChatAddResDto {
 
     private String chatRoomUuid;
     private Long chatId;

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddRestDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddRestDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class PrivateChatAddRestDto {
 
     private String chatRoomUuid;
+    private Long chatId;
 }

--- a/connet/src/main/java/houseInception/connet/dto/PrivateGptChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateGptChatAddDto.java
@@ -1,0 +1,13 @@
+package houseInception.connet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrivateGptChatAddDto {
+
+    private String message;
+}

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -22,6 +22,7 @@ public interface PrivateRoomCustomRepository {
     boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId);
     boolean existsAlivePrivateRoomUser(Long userId, String privateRoomUuid);
     Long getPrivateRoomIdOfChat(Long privateChatId);
+    Long getTargetIdInChatRoom(Long userId, Long privateRoomId);
 
     List<PrivateChatResDto> getPrivateChatList(Long userId, Long privateRoomId, int page);
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -14,6 +14,7 @@ public interface PrivateRoomCustomRepository {
 
     Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid);
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
+    Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
 
     Map<Long, PrivateRoomResDto> getPrivateRoomList(Long userId, int page);
@@ -22,7 +23,6 @@ public interface PrivateRoomCustomRepository {
     boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId);
     boolean existsAlivePrivateRoomUser(Long userId, String privateRoomUuid);
     Long getPrivateRoomIdOfChat(Long privateChatId);
-    Long getTargetIdInChatRoom(Long userId, Long privateRoomId);
 
     List<PrivateChatResDto> getPrivateChatList(Long userId, Long privateRoomId, int page);
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -16,6 +16,7 @@ public interface PrivateRoomCustomRepository {
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
     Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
+    Optional<PrivateChat> findPrivateChatsById(Long privateChatId);
 
     Map<Long, PrivateRoomResDto> getPrivateRoomList(Long userId, int page);
     List<Long> getLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList);

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -88,10 +88,24 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
 
     @Override
     public Long getPrivateRoomIdOfChat(Long privateChatId) {
-        return query.select(privateChat.privateRoom.id)
+        return query
+                .select(privateChat.privateRoom.id)
                 .from(privateChat)
                 .where(privateChat.id.eq(privateChatId),
                         privateChat.status.eq(ALIVE))
+                .fetchOne();
+    }
+
+    @Override
+    public Long getTargetIdInChatRoom(Long userId, Long privateRoomId) {
+        return query
+                .select(user.id)
+                .from(privateRoomUser)
+                .innerJoin(privateRoom).on(privateRoom.id.eq(privateRoomUser.privateRoom.id))
+                .innerJoin(user).on(user.id.eq(privateRoomUser.user.id))
+                .where(user.id.ne(userId),
+                        privateRoom.id.eq(privateRoomId),
+                        privateRoom.status.eq(ALIVE))
                 .fetchOne();
     }
 

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -60,6 +60,15 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     }
 
     @Override
+    public Optional<PrivateChat> findPrivateChatsById(Long privateChatId) {
+        PrivateChat findPrivateChat = query.selectFrom(privateChat)
+                .where(privateChat.id.eq(privateChatId))
+                .fetchOne();
+
+        return Optional.ofNullable(findPrivateChat);
+    }
+
+    @Override
     public boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId) {
         Long count = query.select(privateRoomUser.count())
                 .from(privateRoomUser)

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -6,8 +6,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.domain.ChatRoomType;
-import houseInception.connet.domain.QChatEmoji;
-import houseInception.connet.domain.Status;
 import houseInception.connet.domain.privateRoom.*;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.dto.PrivateChatResDto;
@@ -96,17 +94,17 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                 .fetchOne();
     }
 
-    @Override
-    public Long getTargetIdInChatRoom(Long userId, Long privateRoomId) {
-        return query
-                .select(user.id)
-                .from(privateRoomUser)
+    public Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId) {
+        PrivateRoomUser targetPrivateRoomUser = query
+                .selectFrom(privateRoomUser)
                 .innerJoin(privateRoom).on(privateRoom.id.eq(privateRoomUser.privateRoom.id))
-                .innerJoin(user).on(user.id.eq(privateRoomUser.user.id))
+                .innerJoin(privateRoomUser.user, user).fetchJoin()
                 .where(user.id.ne(userId),
                         privateRoom.id.eq(privateRoomId),
                         privateRoom.status.eq(ALIVE))
                 .fetchOne();
+
+        return Optional.ofNullable(targetPrivateRoomUser);
     }
 
     @Override

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -136,8 +136,8 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                                 "emojiAggStr")
                 ))
                 .from(privateChat)
-                .innerJoin(privateRoomUser).on(privateRoomUser.id.eq(privateChat.writer.id))
-                .innerJoin(user).on(user.id.eq(privateRoomUser.user.id))
+                .leftJoin(privateRoomUser).on(privateRoomUser.id.eq(privateChat.writer.id))
+                .leftJoin(user).on(user.id.eq(privateRoomUser.user.id))
                 .where(privateChat.privateRoom.id.eq(privateRoomId),
                         privateChat.createdAt.goe(
                                 JPAExpressions.select(subPrivateRoomUser.participationTime)

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -75,10 +75,10 @@ public class PrivateRoomService {
         checkRoomUserAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
 
         PrivateChatSocketDto privateChatSocketDto =
-                new PrivateChatSocketDto(privateRoom.getPrivateRoomUuid(), chatAddDto.getMessage(), imgUrl, ChatterRole.USER, user, privateChat.getCreatedAt());
+                new PrivateChatSocketDto(privateRoom.getPrivateRoomUuid(), privateChat.getId(), chatAddDto.getMessage(), imgUrl, ChatterRole.USER, user, privateChat.getCreatedAt());
         socketServiceProvider.sendMessage(targetId, privateChatSocketDto);
 
-        return new PrivateChatAddRestDto(privateRoom.getPrivateRoomUuid());
+        return new PrivateChatAddRestDto(privateRoom.getPrivateRoomUuid(), privateChat.getId());
     }
 
     private void checkRoomUserAndSetAlive(PrivateRoomUser privateRoomUser, PrivateRoom privateRoom, LocalDateTime participationTime){

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -17,6 +17,7 @@ import houseInception.connet.socketManager.SocketServiceProvider;
 import houseInception.connet.socketManager.dto.PrivateChatSocketDto;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
 import static houseInception.connet.response.status.BaseErrorCode.*;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -144,7 +146,7 @@ public class PrivateRoomService {
         PrivateChat gptPrivateChat = privateRoom.addGptToUserChat(gptResponse);
         em.flush();
 
-        sendMessageThrowSocket(targetId, privateRoomUuid, gptPrivateChat.getId(), message, null, ChatterRole.USER, user, gptPrivateChat.getCreatedAt());
+        sendMessageThrowSocket(targetId, privateRoomUuid, gptPrivateChat.getId(), gptResponse, null, ChatterRole.GPT, user, gptPrivateChat.getCreatedAt());
 
         checkRoomUserAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
         checkRoomUserAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());

--- a/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatSocketDto.java
+++ b/connet/src/main/java/houseInception/connet/socketManager/dto/PrivateChatSocketDto.java
@@ -13,14 +13,16 @@ public class PrivateChatSocketDto {
 
     private ChatMessageType type = PRIVATE;
     private String chatRoomUuid;
+    private Long chatId;
     private String message;
     private String image;
     private ChatterRole writerRole;
     private ChatterResDto writer;
     private LocalDateTime createAt;
 
-    public PrivateChatSocketDto(String chatRoomUuid, String message, String image, ChatterRole writerRole, User user, LocalDateTime createAt) {
+    public PrivateChatSocketDto(String chatRoomUuid, Long chatId, String message, String image, ChatterRole writerRole, User user, LocalDateTime createAt) {
         this.chatRoomUuid = chatRoomUuid;
+        this.chatId = chatId;
         this.message = message;
         this.image = image;
         this.writerRole = writerRole;

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -5,7 +5,7 @@ import houseInception.connet.domain.privateRoom.PrivateChat;
 import houseInception.connet.domain.privateRoom.PrivateRoom;
 import houseInception.connet.domain.privateRoom.PrivateRoomUser;
 import houseInception.connet.dto.PrivateChatAddDto;
-import houseInception.connet.dto.PrivateChatAddRestDto;
+import houseInception.connet.dto.PrivateChatAddResDto;
 import houseInception.connet.dto.PrivateChatResDto;
 import houseInception.connet.dto.PrivateRoomResDto;
 import houseInception.connet.exception.PrivateRoomException;
@@ -18,12 +18,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Commit;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -69,7 +66,7 @@ class PrivateRoomServiceTest {
         //when
         String message = "mess1";
         PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
-        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
+        PrivateChatAddResDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
 
         //then
         PrivateRoom privateRoom = privateRoomRepository.findPrivateRoomWithUser(result.getChatRoomUuid()).orElse(null);
@@ -94,7 +91,7 @@ class PrivateRoomServiceTest {
         //when
         String message = "mess1";
         PrivateChatAddDto chatAddDto = new PrivateChatAddDto(privateRoom.getPrivateRoomUuid(), message, null);
-        PrivateChatAddRestDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
+        PrivateChatAddResDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
 
         //then
         List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -4,10 +4,7 @@ import houseInception.connet.domain.*;
 import houseInception.connet.domain.privateRoom.PrivateChat;
 import houseInception.connet.domain.privateRoom.PrivateRoom;
 import houseInception.connet.domain.privateRoom.PrivateRoomUser;
-import houseInception.connet.dto.PrivateChatAddDto;
-import houseInception.connet.dto.PrivateChatAddResDto;
-import houseInception.connet.dto.PrivateChatResDto;
-import houseInception.connet.dto.PrivateRoomResDto;
+import houseInception.connet.dto.*;
 import houseInception.connet.exception.PrivateRoomException;
 import houseInception.connet.repository.PrivateRoomRepository;
 import houseInception.connet.repository.UserBlockRepository;
@@ -112,6 +109,27 @@ class PrivateRoomServiceTest {
         String message = "mess1";
         PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
         assertThatThrownBy(() -> privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto)).isInstanceOf(PrivateRoomException.class);
+    }
+
+    @Test
+    void addGptChat() {
+        //given
+        PrivateRoom privateRoom = PrivateRoom.create(user1, user2);
+        em.persist(privateRoom);
+
+        //when
+        String message = "한국의 위도 경도를 알려줘";
+        GptPrivateChatAddResDto result = privateRoomService.addGptChat(user1.getId(), privateRoom.getPrivateRoomUuid(), message);
+
+        //then
+        PrivateChat userChat = privateRoomRepository.findPrivateChatsById(result.getUserChatId()).orElse(null);
+        assertThat(userChat).isNotNull();
+        assertThat(userChat.getMessage()).isEqualTo(message);
+
+        PrivateChat gptChat = privateRoomRepository.findPrivateChatsById(result.getGptChatId()).orElse(null);
+        assertThat(gptChat).isNotNull();
+        assertThat(gptChat.getMessage()).isEqualTo(result.getMessage());
+        log.info("gpt response = {}", result.getMessage());
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -29,13 +29,8 @@ class PrivateRoomServiceTest {
 
     @Autowired
     PrivateRoomService privateRoomService;
-
-    @Autowired
-    UserRepository userRepository;
     @Autowired
     PrivateRoomRepository privateRoomRepository;
-    @Autowired
-    UserBlockRepository userBlockRepository;
 
     @Autowired
     EntityManager em;
@@ -52,10 +47,10 @@ class PrivateRoomServiceTest {
         user3 = User.create("user3", null, null, null);
         user4 = User.create("user4", null, null, null);
 
-        userRepository.save(user1);
-        userRepository.save(user2);
-        userRepository.save(user3);
-        userRepository.save(user4);
+        em.persist(user1);
+        em.persist(user2);
+        em.persist(user3);
+        em.persist(user4);
     }
 
     @Test
@@ -102,8 +97,8 @@ class PrivateRoomServiceTest {
         UserBlock userBlock = UserBlock.create(user2, user1, UserBlockType.REQUEST);
         UserBlock reverseUserBlock = UserBlock.create(user1, user2, UserBlockType.ACCEPT);
 
-        userBlockRepository.save(userBlock);
-        userBlockRepository.save(reverseUserBlock);
+        em.persist(userBlock);
+        em.persist(reverseUserBlock);
 
         //when
         String message = "mess1";


### PR DESCRIPTION
## 관련 이슈 번호

- #59 

<br />

## 작업 사항

- 개인 채팅방에 gpt 채팅 전송 기능 구현 및 테스트
- 개인 채팅방에 채팅 전송 요청시 응답에 채팅의 고유 아이디 정보 추가
- 개인 채팅방의 채팅 목록 조회 시 inner join문제로 gpt의 응답 채팅이 조회되지 않는 문제 해결
- gpt의 응답이 길때 database의 오류 발생, message를 Lob타입으로 선언
- 기타 리팩토링

<br />

## 기타 사항
<br />
