### PR TITLE
개인 채팅방에서 채팅 전송 & 채팅방 생성 로직 변경

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
@@ -23,11 +23,11 @@ public class PrivateRoomController {
         return new BaseResponse<>(result);
     }
 
-    @PostMapping("/{privateRoomUuid}/gpt")
-    public BaseResponse<GptPrivateChatAddResDto> addGptChat(@PathVariable String privateRoomUuid,
+    @PostMapping("/{targetId}/gpt")
+    public BaseResponse<GptPrivateChatAddResDto> addGptChat(@PathVariable Long targetId,
                                                             @RequestBody PrivateGptChatAddDto gptChatAddDto){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        GptPrivateChatAddResDto result = privateRoomService.addGptChat(userId, privateRoomUuid, gptChatAddDto.getMessage());
+        GptPrivateChatAddResDto result = privateRoomService.addGptChat(userId, targetId, gptChatAddDto.getMessage());
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/dto/GptPrivateChatAddResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/GptPrivateChatAddResDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class GptPrivateChatAddResDto {
 
+    private String chatRoomUuId;
     private Long userChatId;
     private LocalDateTime userChatCreateAt;
     private Long gptChatId;

--- a/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateChatAddDto.java
@@ -11,7 +11,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PrivateChatAddDto {
 
-    private String chatRoomUuid;
     private String message;
     private MultipartFile image;
 }

--- a/connet/src/main/java/houseInception/connet/dto/PrivateGptChatAddDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateGptChatAddDto.java
@@ -1,5 +1,6 @@
 package houseInception.connet.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PrivateGptChatAddDto {
 
+    @NotBlank
     private String message;
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface PrivateRoomCustomRepository {
 
     Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid);
+    Optional<PrivateRoom> findPrivateRoomByUsers(Long userId, Long targetId);
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
     Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -15,7 +15,7 @@ public interface PrivateRoomCustomRepository {
     Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid);
     Optional<PrivateRoom> findPrivateRoomByUsers(Long userId, Long targetId);
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
-    Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId);
+    Optional<PrivateRoomUser> findTargetRoomUserInChatRoom(Long userId, Long privateRoomId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
     Optional<PrivateChat> findPrivateChatsById(Long privateChatId);
 

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -119,12 +119,11 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                 .fetchOne();
     }
 
-    public Optional<PrivateRoomUser> findTargetRoomUserWithUserInChatRoom(Long userId, Long privateRoomId) {
+    public Optional<PrivateRoomUser> findTargetRoomUserInChatRoom(Long userId, Long privateRoomId) {
         PrivateRoomUser targetPrivateRoomUser = query
                 .selectFrom(privateRoomUser)
                 .innerJoin(privateRoom).on(privateRoom.id.eq(privateRoomUser.privateRoom.id))
-                .innerJoin(privateRoomUser.user, user).fetchJoin()
-                .where(user.id.ne(userId),
+                .where(privateRoomUser.user.id.ne(userId),
                         privateRoom.id.eq(privateRoomId),
                         privateRoom.status.eq(ALIVE))
                 .fetchOne();

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -43,6 +43,22 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     }
 
     @Override
+    public Optional<PrivateRoom> findPrivateRoomByUsers(Long userId, Long targetId) {
+        QPrivateRoomUser subPrivateUser = new QPrivateRoomUser("subPrivateUser");
+        PrivateRoom fetchedPrivateRoom = query
+                .select(privateRoom)
+                .from(privateRoomUser)
+                .innerJoin(subPrivateUser).on(privateRoomUser.privateRoom.id.eq(subPrivateUser.privateRoom.id))
+                .innerJoin(privateRoomUser.privateRoom, privateRoom)
+                .where(privateRoomUser.user.id.eq(userId),
+                        subPrivateUser.user.id.eq(targetId),
+                        privateRoom.status.eq(ALIVE))
+                .fetchOne();
+
+        return Optional.ofNullable(fetchedPrivateRoom);
+    }
+
+    @Override
     public Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId) {
         PrivateRoomUser findPrivateRoomUser = query.selectFrom(privateRoomUser)
                 .where(privateRoomUser.privateRoom.id.eq(privateRoomId),

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -150,7 +150,7 @@ public class PrivateRoomService {
 
         sendMessageThrowSocket(targetId, privateRoom.getPrivateRoomUuid(), gptPrivateChat.getId(), gptResponse, null, ChatterRole.GPT, user, gptPrivateChat.getCreatedAt());
 
-        return new GptPrivateChatAddResDto(privateChat.getId(), privateChat.getCreatedAt(), gptPrivateChat.getId(), gptPrivateChat.getCreatedAt(), gptResponse);
+        return new GptPrivateChatAddResDto(privateRoom.getPrivateRoomUuid(), privateChat.getId(), privateChat.getCreatedAt(), gptPrivateChat.getId(), gptPrivateChat.getCreatedAt(), gptResponse);
     }
     
     private PrivateRoom getOrCreatePrivateRoom(Optional<PrivateRoom> nullablePrivateRoom, User user, User targetUser){

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
@@ -56,34 +56,35 @@ public class PrivateRoomService {
         User targetUser = findUser(targetId);
         User user = findUser(userId);
 
-        checkHasUserBlock(userId, targetId);
         checkValidContent(chatAddDto.getMessage(), chatAddDto.getImage());
+        checkHasUserBlock(userId, targetId);
 
+        Optional<PrivateRoom> nullablePrivateRoom = privateRoomRepository.findPrivateRoomByUsers(userId, targetId);
         PrivateRoom privateRoom;
-        if (chatAddDto.getChatRoomUuid() == null || chatAddDto.getChatRoomUuid().isBlank()) {
+
+        if (nullablePrivateRoom.isEmpty()) {
             privateRoom = PrivateRoom.create(user, targetUser);
             privateRoomRepository.save(privateRoom);
         } else {
-            privateRoom = findPrivateRoom(chatAddDto.getChatRoomUuid());
+            privateRoom = nullablePrivateRoom.get();
         }
-
-        PrivateRoomUser privateRoomSender = findPrivateRoomUser(privateRoom.getId(), userId);
 
         String imgUrl = uploadImages(chatAddDto.getImage());
 
+        PrivateRoomUser privateRoomSender = findPrivateRoomUser(privateRoom.getId(), userId);
         PrivateChat privateChat = privateRoom.addUserToUserChat(chatAddDto.getMessage(), imgUrl, privateRoomSender);
         em.flush();
 
         PrivateRoomUser privateRoomReceiver = findPrivateRoomUser(privateRoom.getId(), targetId);
-        checkRoomUserAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
-        checkRoomUserAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
+        checkRoomUserDeletedAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
+        checkRoomUserDeletedAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
 
         sendMessageThrowSocket(targetId, privateRoom.getPrivateRoomUuid(), privateChat.getId(), chatAddDto.getMessage(), imgUrl, ChatterRole.USER, user, privateChat.getCreatedAt());
 
         return new PrivateChatAddResDto(privateRoom.getPrivateRoomUuid(), privateChat.getId());
     }
 
-    private void checkRoomUserAndSetAlive(PrivateRoomUser privateRoomUser, PrivateRoom privateRoom, LocalDateTime participationTime){
+    private void checkRoomUserDeletedAndSetAlive(PrivateRoomUser privateRoomUser, PrivateRoom privateRoom, LocalDateTime participationTime){
         if (privateRoomUser.getStatus() == DELETED) {
             privateRoom.setPrivateRoomUserAlive(privateRoomUser, participationTime);
         }
@@ -149,8 +150,8 @@ public class PrivateRoomService {
 
         sendMessageThrowSocket(targetId, privateRoomUuid, gptPrivateChat.getId(), gptResponse, null, ChatterRole.GPT, user, gptPrivateChat.getCreatedAt());
 
-        checkRoomUserAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
-        checkRoomUserAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
+        checkRoomUserDeletedAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
+        checkRoomUserDeletedAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
 
         return new GptPrivateChatAddResDto(privateChat.getId(), privateChat.getCreatedAt(), gptPrivateChat.getId(), gptPrivateChat.getCreatedAt(), gptResponse);
     }

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -108,14 +108,14 @@ class PrivateRoomServiceTest {
     }
 
     @Test
-    void addGptChat() {
+    void addGptChat_채팅방_존재() {
         //given
         PrivateRoom privateRoom = PrivateRoom.create(user1, user2);
         em.persist(privateRoom);
 
         //when
         String message = "한국의 위도 경도를 알려줘";
-        GptPrivateChatAddResDto result = privateRoomService.addGptChat(user1.getId(), privateRoom.getPrivateRoomUuid(), message);
+        GptPrivateChatAddResDto result = privateRoomService.addGptChat(user1.getId(), user2.getId(), message);
 
         //then
         PrivateChat userChat = privateRoomRepository.findPrivateChatsById(result.getUserChatId()).orElse(null);

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -54,10 +54,10 @@ class PrivateRoomServiceTest {
     }
 
     @Test
-    void addPrivateChat_채팅방X_파일X() {
+    void addPrivateChat_채팅방_생성_파일X() {
         //when
         String message = "mess1";
-        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(message, null);
         PrivateChatAddResDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
 
         //then
@@ -65,30 +65,29 @@ class PrivateRoomServiceTest {
         assertThat(privateRoom).isNotNull();
 
         List<PrivateRoomUser> privateRoomUsers = privateRoom.getPrivateRoomUsers();
-        assertThat(privateRoomUsers.size()).isEqualTo(2);
-        assertThat(privateRoomUsers.stream().map(PrivateRoomUser::getUser))
-                .extracting("id").contains(user1.getId(), user2.getId());
+        assertThat(privateRoomUsers).hasSize(2);
+        assertThat(privateRoomUsers)
+                .extracting(roomUser -> roomUser.getUser().getId())
+                .containsExactlyInAnyOrder(user1.getId(), user2.getId());
+
 
         List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());
-        assertThat(privateChats.size()).isEqualTo(1);
+        assertThat(privateChats).hasSize(1);
         assertThat(privateChats.get(0).getMessage()).isEqualTo(message);
     }
 
     @Test
-    void addPrivateChat_채팅방O_파일X() {
+    void addPrivateChat_채팅방_존재() {
         //given
         PrivateRoom privateRoom = PrivateRoom.create(user1, user2);
         privateRoomRepository.save(privateRoom);
 
         //when
-        String message = "mess1";
-        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(privateRoom.getPrivateRoomUuid(), message, null);
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto("mess1", null);
         PrivateChatAddResDto result = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto);
 
         //then
-        List<PrivateChat> privateChats = privateRoomRepository.findPrivateChatsInPrivateRoom(privateRoom.getId());
-        assertThat(privateChats.size()).isEqualTo(1);
-        assertThat(privateChats.get(0).getMessage()).isEqualTo(message);
+        assertThat(result.getChatRoomUuid()).isEqualTo(privateRoom.getPrivateRoomUuid());
     }
 
     @Test
@@ -101,9 +100,11 @@ class PrivateRoomServiceTest {
         em.persist(reverseUserBlock);
 
         //when
-        String message = "mess1";
-        PrivateChatAddDto chatAddDto = new PrivateChatAddDto(null, message, null);
-        assertThatThrownBy(() -> privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto)).isInstanceOf(PrivateRoomException.class);
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto("mess1", null);
+        assertThatThrownBy(() -> privateRoomService.addPrivateChat(user1.getId(), user2.getId(), chatAddDto))
+                .isInstanceOf(PrivateRoomException.class);
+        assertThatThrownBy(() -> privateRoomService.addPrivateChat(user2.getId(), user1.getId(), chatAddDto))
+                .isInstanceOf(PrivateRoomException.class);
     }
 
     @Test
@@ -149,7 +150,7 @@ class PrivateRoomServiceTest {
         List<PrivateRoomResDto> result = privateRoomService.getPrivateRoomList(user1.getId(), 1).getData();
 
         //then
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).hasSize(3);
         assertThat(result).extracting("chatRoomId").containsExactly(privateRoom1.getId(), privateRoom3.getId(), privateRoom2.getId());
     }
 
@@ -173,7 +174,7 @@ class PrivateRoomServiceTest {
         List<PrivateChatResDto> result = privateRoomService.getPrivateChatList(user1.getId(), privateRoom1.getPrivateRoomUuid(), 1).getData();
 
         //then
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
         assertThat(result).extracting("chatId").containsExactly(privateChat2.getId(), privateChat1.getId());
 
         PrivateChatResDto chatDto = result.get(1);
@@ -209,32 +210,32 @@ class PrivateRoomServiceTest {
     @Test
     void 채팅방_퇴장후_목록_조회() {
         //given
-        String chatRoomUuid1 = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), new PrivateChatAddDto(null, "message", null)).getChatRoomUuid();
-        String chatRoomUuid2 = privateRoomService.addPrivateChat(user1.getId(), user3.getId(), new PrivateChatAddDto(null, "message", null)).getChatRoomUuid();
-        String chatRoomUuid3 = privateRoomService.addPrivateChat(user1.getId(), user4.getId(), new PrivateChatAddDto(null, "message", null)).getChatRoomUuid();
+        String chatRoomUuid1 = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), new PrivateChatAddDto("message", null)).getChatRoomUuid();
+        String chatRoomUuid2 = privateRoomService.addPrivateChat(user1.getId(), user3.getId(), new PrivateChatAddDto("message", null)).getChatRoomUuid();
+        String chatRoomUuid3 = privateRoomService.addPrivateChat(user1.getId(), user4.getId(), new PrivateChatAddDto("message", null)).getChatRoomUuid();
         privateRoomService.deletePrivateRoom(user1.getId(), chatRoomUuid1);
 
         //when
         List<PrivateRoomResDto> result = privateRoomService.getPrivateRoomList(user1.getId(), 1).getData();
 
         //then
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
         assertThat(result).extracting("chatRoomUuid").contains(chatRoomUuid2, chatRoomUuid3);
     }
 
     @Test
     void 채팅방_퇴장후_재입장_채팅목록_조회() {
         //given
-        String chatRoomUuid1 = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), new PrivateChatAddDto(null, "message", null)).getChatRoomUuid();
+        String chatRoomUuid1 = privateRoomService.addPrivateChat(user1.getId(), user2.getId(), new PrivateChatAddDto("message", null)).getChatRoomUuid();
         privateRoomService.deletePrivateRoom(user1.getId(), chatRoomUuid1);
-        privateRoomService.addPrivateChat(user2.getId(), user1.getId(), new PrivateChatAddDto(chatRoomUuid1, "message", null));
+        privateRoomService.addPrivateChat(user2.getId(), user1.getId(), new PrivateChatAddDto("message", null));
 
         //when
         List<PrivateChatResDto> data1 = privateRoomService.getPrivateChatList(user1.getId(), chatRoomUuid1, 1).getData();
         List<PrivateChatResDto> data2 = privateRoomService.getPrivateChatList(user2.getId(), chatRoomUuid1, 1).getData();
 
         //then
-        assertThat(data1.size()).isEqualTo(1);
-        assertThat(data2.size()).isEqualTo(2);
+        assertThat(data1).hasSize(1);
+        assertThat(data2).hasSize(2);
     }
 }

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -151,7 +151,8 @@ class PrivateRoomServiceTest {
 
         //then
         assertThat(result).hasSize(3);
-        assertThat(result).extracting("chatRoomId").containsExactly(privateRoom1.getId(), privateRoom3.getId(), privateRoom2.getId());
+        assertThat(result).extracting(PrivateRoomResDto::getChatRoomId)
+                .containsExactly(privateRoom1.getId(), privateRoom3.getId(), privateRoom2.getId());
     }
 
     @Test
@@ -175,11 +176,17 @@ class PrivateRoomServiceTest {
 
         //then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting("chatId").containsExactly(privateChat2.getId(), privateChat1.getId());
+        assertThat(result)
+                .extracting(PrivateChatResDto::getChatId)
+                .containsExactly(privateChat2.getId(), privateChat1.getId());
 
-        PrivateChatResDto chatDto = result.get(1);
-        assertThat(chatDto.getEmoji()).extracting("emojiType").contains(EmojiType.HEART, EmojiType.CHECK);
-        assertThat(chatDto.getEmoji()).extracting("count").contains(1, 2);
+        List<ChatEmojiResDto> emojiList = result.get(1).getEmoji();
+        assertThat(emojiList)
+                .extracting(ChatEmojiResDto::getEmojiType)
+                .contains(EmojiType.HEART, EmojiType.CHECK);
+        assertThat(emojiList)
+                .extracting(ChatEmojiResDto::getCount)
+                .contains(1, 2);
     }
 
     @Test
@@ -204,7 +211,8 @@ class PrivateRoomServiceTest {
         privateRoomRepository.save(privateRoom1);
 
         //when
-        assertThatThrownBy(() -> privateRoomService.deletePrivateRoom(user3.getId(), privateRoom1.getPrivateRoomUuid())).isInstanceOf(PrivateRoomException.class);
+        assertThatThrownBy(() -> privateRoomService.deletePrivateRoom(user3.getId(), privateRoom1.getPrivateRoomUuid()))
+                .isInstanceOf(PrivateRoomException.class);
     }
 
     @Test
@@ -220,7 +228,8 @@ class PrivateRoomServiceTest {
 
         //then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting("chatRoomUuid").contains(chatRoomUuid2, chatRoomUuid3);
+        assertThat(result).extracting(PrivateRoomResDto::getChatRoomUuid)
+                .contains(chatRoomUuid2, chatRoomUuid3);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 번호

- #94 

<br />

## 작업 사항

- 개인 채팅 전송시 chatRoomUuid가 아닌 타겟 유저의 고유 아이디 만으로 가능하게끔 변경
따라서 전송 유저와 타겟 유저간 하나의 PrivateChatRoom이 존재하게끔 보장됨.
유저 우클릭 후 채팅 전송 기능 제공을 위해 chatRoomUuid와 userId로 채팅 전송이 가능하게 끔 분리하기 보다는 하나로 통일함. 
- 개인 채팅에서 채팅방을 생성하지 않고 바로 gpt 채팅을 전송하며 채팅방이 생성되게끔 로직 변경

<br />

## 기타 사항
<br />
