### PR TITLE
개인 채팅방 목록 조회, 채팅 목록 조회 기능 보강

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/PrivateRoomController.java
@@ -48,11 +48,11 @@ public class PrivateRoomController {
         return new BaseResponse<>(result);
     }
 
-    @GetMapping("/{privateRoomUuid}/chats")
-    public BaseResponse<DataListResDto<PrivateChatResDto>> getPrivateChatList(@PathVariable String privateRoomUuid,
+    @GetMapping("/{targetId}/chats")
+    public BaseResponse<DataListResDto<PrivateChatResDto>> getPrivateChatList(@PathVariable Long targetId,
                                                                               @RequestParam(defaultValue = "1") int page){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<PrivateChatResDto> result = privateRoomService.getPrivateChatList(userId, privateRoomUuid, page);
+        DataListResDto<PrivateChatResDto> result = privateRoomService.getPrivateChatList(userId, targetId, page);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/dto/DataListResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/DataListResDto.java
@@ -2,6 +2,7 @@ package houseInception.connet.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -9,6 +10,6 @@ import java.util.List;
 @AllArgsConstructor
 public class DataListResDto<T> {
 
-    private int page;
+    private int page = 0;
     private List<T> data;
 }

--- a/connet/src/main/java/houseInception/connet/dto/PrivateRoomResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/PrivateRoomResDto.java
@@ -16,14 +16,16 @@ public class PrivateRoomResDto {
     private String userName;
     private String userProfile;
     private boolean isActive;
+    private boolean isBlock;
 
     @QueryProjection
-    public PrivateRoomResDto(Long chatRoomId, String chatRoomUuid, Long userId, String userName, String userProfile, boolean isActive) {
+    public PrivateRoomResDto(Long chatRoomId, String chatRoomUuid, Long userId, String userName, String userProfile, boolean isActive, Long blockId) {
         this.chatRoomId = chatRoomId;
         this.chatRoomUuid = chatRoomUuid;
         this.userId = userId;
         this.userName = userName;
         this.userProfile = userProfile;
         this.isActive = isActive;
+        this.isBlock = blockId == null? false : true;
     }
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -23,7 +23,6 @@ public interface PrivateRoomCustomRepository {
     List<Long> getLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList);
 
     boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId);
-    boolean existsAlivePrivateRoomUser(Long userId, String privateRoomUuid);
     Long getPrivateRoomIdOfChat(Long privateChatId);
 
     List<PrivateChatResDto> getPrivateChatList(Long userId, Long privateRoomId, int page);

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -97,19 +97,6 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     }
 
     @Override
-    public boolean existsAlivePrivateRoomUser(Long userId, String privateRoomUuid) {
-        Long count = query.select(privateRoomUser.count())
-                .from(privateRoomUser)
-                .innerJoin(privateRoom).on(privateRoom.id.eq(privateRoomUser.privateRoom.id))
-                .where(privateRoom.privateRoomUuid.eq(privateRoomUuid),
-                        privateRoomUser.user.id.eq(userId),
-                        privateRoomUser.status.eq(ALIVE))
-                .fetchOne();
-
-        return count != null && count > 0;
-    }
-
-    @Override
     public Long getPrivateRoomIdOfChat(Long privateChatId) {
         return query
                 .select(privateChat.privateRoom.id)

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomRepository.java
@@ -11,7 +11,4 @@ import java.util.Optional;
 public interface PrivateRoomRepository extends JpaRepository<PrivateRoom, Long>, PrivateRoomCustomRepository {
 
     Optional<PrivateRoom> findByPrivateRoomUuidAndStatus(String privateRoomUuid, Status status);
-
-    @Query("SELECT p.id FROM PrivateRoom p WHERE p.privateRoomUuid = :privateRoomUuid AND p.status = ALIVE")
-    Long findIdByPrivateRoomUuid(@Param("privateRoomUuid") String privateRoomUuid);
 }

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -196,21 +196,6 @@ public class PrivateRoomService {
         return new DataListResDto<>(page, privateChatList);
     }
 
-    private Long checkExistPrivateRoomAndGetId(String privateRoomUuid){
-        Long privateRoomId = privateRoomRepository.findIdByPrivateRoomUuid(privateRoomUuid);
-        if (privateRoomId == null){
-            throw new PrivateRoomException(NO_SUCH_CHATROOM);
-        }
-
-        return privateRoomId;
-    }
-
-    private void checkUserInPrivateRoom(Long userId, String privateRoomUuid) {
-        if (!privateRoomRepository.existsAlivePrivateRoomUser(userId, privateRoomUuid)){
-            throw new PrivateRoomException(NOT_CHATROOM_USER);
-        }
-    }
-
     private void checkHasUserBlock(Long userId, Long targetId) {
         if(userBlockRepository.existsByUserIdAndTargetId(userId, targetId)){
             throw new PrivateRoomException(BLOCK_USER);

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -25,10 +25,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
@@ -188,11 +185,13 @@ public class PrivateRoomService {
         return new DataListResDto<>(page, resultList);
     }
 
-    public DataListResDto<PrivateChatResDto> getPrivateChatList(Long userId, String privateRoomUuid, int page) {
-        Long privateRoomId = checkExistPrivateRoomAndGetId(privateRoomUuid);
-        checkUserInPrivateRoom(userId, privateRoomUuid);
+    public DataListResDto<PrivateChatResDto> getPrivateChatList(Long userId, Long targetId, int page) {
+        Optional<PrivateRoom> privateRoom = privateRoomRepository.findPrivateRoomByUsers(userId, targetId);
+        if(privateRoom.isEmpty()){
+            return new DataListResDto<>(page, new ArrayList<>());
+        }
 
-        List<PrivateChatResDto> privateChatList = privateRoomRepository.getPrivateChatList(userId, privateRoomId, page);
+        List<PrivateChatResDto> privateChatList = privateRoomRepository.getPrivateChatList(userId, privateRoom.get().getId(), page);
 
         return new DataListResDto<>(page, privateChatList);
     }

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -172,7 +172,7 @@ class PrivateRoomServiceTest {
         em.persist(chatEmoji3);
 
         //when
-        List<PrivateChatResDto> result = privateRoomService.getPrivateChatList(user1.getId(), privateRoom1.getPrivateRoomUuid(), 1).getData();
+        List<PrivateChatResDto> result = privateRoomService.getPrivateChatList(user1.getId(), user2.getId(), 1).getData();
 
         //then
         assertThat(result).hasSize(2);
@@ -240,8 +240,8 @@ class PrivateRoomServiceTest {
         privateRoomService.addPrivateChat(user2.getId(), user1.getId(), new PrivateChatAddDto("message", null));
 
         //when
-        List<PrivateChatResDto> data1 = privateRoomService.getPrivateChatList(user1.getId(), chatRoomUuid1, 1).getData();
-        List<PrivateChatResDto> data2 = privateRoomService.getPrivateChatList(user2.getId(), chatRoomUuid1, 1).getData();
+        List<PrivateChatResDto> data1 = privateRoomService.getPrivateChatList(user1.getId(), user2.getId(), 1).getData();
+        List<PrivateChatResDto> data2 = privateRoomService.getPrivateChatList(user2.getId(), user1.getId(), 1).getData();
 
         //then
         assertThat(data1).hasSize(1);

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -146,13 +146,20 @@ class PrivateRoomServiceTest {
         privateRoom1.addUserToUserChat("message", null, privateRoom1.getPrivateRoomUsers().get(0));
         em.flush();
 
+        UserBlock userBlock = UserBlock.create(user1, user4, UserBlockType.REQUEST);
+        em.persist(userBlock);
+
         //when
         List<PrivateRoomResDto> result = privateRoomService.getPrivateRoomList(user1.getId(), 1).getData();
 
         //then
         assertThat(result).hasSize(3);
-        assertThat(result).extracting(PrivateRoomResDto::getChatRoomId)
+        assertThat(result)
+                .extracting(PrivateRoomResDto::getChatRoomId)
                 .containsExactly(privateRoom1.getId(), privateRoom3.getId(), privateRoom2.getId());
+        assertThat(result)
+                .extracting(PrivateRoomResDto::isBlock)
+                .containsExactly(false, true, false);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 번호

- #94 

<br />

## 작업 사항

- 개인 채팅방의 채팅 목록 조회시 chatRoomUuid가 아닌 targetId로 조회가 가능하도록 path parameter 변경
- 개인 채팅방 목록 조회시 상대 유저의 차단 유무 정보 추가

<br />

## 기타 사항
<br />
