### PR TITLE
유효한 파일인지 검증하는 로직 오류 수정

### DIFF
--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -12,7 +12,6 @@ import houseInception.connet.externalServiceProvider.gpt.GptApiProvider;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.PrivateRoomRepository;
 import houseInception.connet.service.util.DomainValidatorUtil;
-import houseInception.connet.service.util.FileUtil;
 import houseInception.connet.socketManager.SocketServiceProvider;
 import houseInception.connet.socketManager.dto.PrivateChatSocketDto;
 import jakarta.persistence.EntityManager;
@@ -31,7 +30,7 @@ import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.Status.DELETED;
 import static houseInception.connet.response.status.BaseErrorCode.*;
 import static houseInception.connet.service.util.FileUtil.getUniqueFileName;
-import static houseInception.connet.service.util.FileUtil.isValidFile;
+import static houseInception.connet.service.util.FileUtil.isInValidFile;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -91,7 +90,7 @@ public class PrivateRoomService {
     }
 
     private String uploadImages(MultipartFile image){
-        if (isValidFile(image)) {
+        if (isInValidFile(image)) {
             return null;
         }
 

--- a/connet/src/main/java/houseInception/connet/service/util/FileUtil.java
+++ b/connet/src/main/java/houseInception/connet/service/util/FileUtil.java
@@ -11,8 +11,8 @@ import static houseInception.connet.response.status.BaseErrorCode.NO_VALID_FILE_
 @Component
 public class FileUtil {
 
-    public static boolean isValidFile(MultipartFile file){
-        return file != null && !file.getOriginalFilename().isBlank();
+    public static boolean isInValidFile(MultipartFile file){
+        return file == null || file.getOriginalFilename() == null || file.getOriginalFilename().isBlank();
     }
 
     public static String getUniqueFileName(String originalFileName){


### PR DESCRIPTION
## 관련 이슈 번호

- #103 

<br />

## 작업 사항

- FileUtil에서 유효한 파일인지 검증하는 로직 오류 수정 및 isInValidFile 로 메서드 명 개선

<br />

## 기타 사항
<br />
