### PR TITLE
그룹 입장, 퇴장 기능 개발

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/GroupController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/GroupController.java
@@ -3,6 +3,7 @@ package houseInception.connet.contoller;
 import houseInception.connet.dto.group.GroupAddDto;
 import houseInception.connet.dto.group.GroupUserResDto;
 import houseInception.connet.response.BaseResponse;
+import houseInception.connet.response.DefaultIdDto;
 import houseInception.connet.response.DefaultUuidDto;
 import houseInception.connet.service.GroupService;
 import jakarta.validation.Valid;
@@ -40,5 +41,13 @@ public class GroupController {
         String resultUuid = groupService.enterGroup(userId, groupUuid);
 
         return BaseResponse.getSimpleRes(resultUuid);
+    }
+
+    @PostMapping("/{groupUuid}/exit")
+    public BaseResponse<DefaultIdDto> exitGroup(@PathVariable String groupUuid){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        Long resultId = groupService.exitGroup(userId, groupUuid);
+
+        return BaseResponse.getSimpleRes(resultId);
     }
 }

--- a/connet/src/main/java/houseInception/connet/contoller/GroupController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/GroupController.java
@@ -1,15 +1,15 @@
 package houseInception.connet.contoller;
 
 import houseInception.connet.dto.group.GroupAddDto;
+import houseInception.connet.dto.group.GroupUserResDto;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.response.DefaultIdDto;
 import houseInception.connet.response.DefaultUuidDto;
 import houseInception.connet.service.GroupService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/groups")
 @RequiredArgsConstructor
@@ -24,5 +24,13 @@ public class GroupController {
         String resultUuid = groupService.addGroup(userId, groupAddDto);
 
         return BaseResponse.getSimpleRes(resultUuid);
+    }
+
+    @GetMapping("/{groupUuid}/groupUsers")
+    public BaseResponse<List<GroupUserResDto>> getGroupUserList(@PathVariable String groupUuid){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        List<GroupUserResDto> result = groupService.getGroupUserList(userId, groupUuid);
+
+        return new BaseResponse<>(result);
     }
 }

--- a/connet/src/main/java/houseInception/connet/contoller/GroupController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/GroupController.java
@@ -3,9 +3,9 @@ package houseInception.connet.contoller;
 import houseInception.connet.dto.group.GroupAddDto;
 import houseInception.connet.dto.group.GroupUserResDto;
 import houseInception.connet.response.BaseResponse;
-import houseInception.connet.response.DefaultIdDto;
 import houseInception.connet.response.DefaultUuidDto;
 import houseInception.connet.service.GroupService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +19,7 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping
-    public BaseResponse<DefaultUuidDto> addGroup(@RequestBody GroupAddDto groupAddDto){
+    public BaseResponse<DefaultUuidDto> addGroup(@RequestBody @Valid GroupAddDto groupAddDto){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         String resultUuid = groupService.addGroup(userId, groupAddDto);
 
@@ -32,5 +32,13 @@ public class GroupController {
         List<GroupUserResDto> result = groupService.getGroupUserList(userId, groupUuid);
 
         return new BaseResponse<>(result);
+    }
+
+    @PostMapping("/{groupUuid}/enter")
+    public BaseResponse<DefaultUuidDto> enterGroup(@PathVariable String groupUuid){
+        Long userId = UserAuthorizationUtil.getLoginUserId();
+        String resultUuid = groupService.enterGroup(userId, groupUuid);
+
+        return BaseResponse.getSimpleRes(resultUuid);
     }
 }

--- a/connet/src/main/java/houseInception/connet/contoller/GroupController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/GroupController.java
@@ -43,7 +43,7 @@ public class GroupController {
         return BaseResponse.getSimpleRes(resultUuid);
     }
 
-    @PostMapping("/{groupUuid}/exit")
+    @DeleteMapping("/{groupUuid}/exit")
     public BaseResponse<DefaultIdDto> exitGroup(@PathVariable String groupUuid){
         Long userId = UserAuthorizationUtil.getLoginUserId();
         Long resultId = groupService.exitGroup(userId, groupUuid);

--- a/connet/src/main/java/houseInception/connet/domain/group/Group.java
+++ b/connet/src/main/java/houseInception/connet/domain/group/Group.java
@@ -60,6 +60,11 @@ public class Group extends BaseTime {
         this.groupUserList.add(groupUser);
     }
 
+    public void addUser(User user){
+        GroupUser groupUser = new GroupUser(user, this, false);
+        this.groupUserList.add(groupUser);
+    }
+
     public boolean addTag(List<String> tags){
         if(!isValidTag(tags)){
             return false;

--- a/connet/src/main/java/houseInception/connet/domain/group/Group.java
+++ b/connet/src/main/java/houseInception/connet/domain/group/Group.java
@@ -65,6 +65,12 @@ public class Group extends BaseTime {
         this.groupUserList.add(groupUser);
     }
 
+    public void removeUser(GroupUser groupUser){
+        if(isGroupUser(groupUser)){
+            groupUser.delete();
+        }
+    }
+
     public boolean addTag(List<String> tags){
         if(!isValidTag(tags)){
             return false;
@@ -84,5 +90,9 @@ public class Group extends BaseTime {
 
     public List<GroupTag> getGroupTagList() {
         return List.copyOf(groupTagList);
+    }
+
+    private boolean isGroupUser(GroupUser groupUser){
+        return groupUser.getGroup().getId().equals(this.id);
     }
 }

--- a/connet/src/main/java/houseInception/connet/domain/group/Group.java
+++ b/connet/src/main/java/houseInception/connet/domain/group/Group.java
@@ -36,19 +36,19 @@ public class Group extends BaseTime {
     private String groupProfile;
     private String groupDescription;
     private int userLimit;
-    private boolean is_open;
+    private boolean isOpen;
 
     @Enumerated(EnumType.STRING)
     private Status status = ALIVE;
 
-    public static Group create(User user, String groupName, String groupProfile, String groupDescription, int userLimit, boolean is_open) {
+    public static Group create(User user, String groupName, String groupProfile, String groupDescription, int userLimit, boolean isOpen) {
         Group group = new Group();
         group.groupUuid = UUID.randomUUID().toString();
         group.groupName = groupName;
         group.groupProfile = groupProfile;
         group.groupDescription = groupDescription;
         group.userLimit = userLimit;
-        group.is_open = is_open;
+        group.isOpen = isOpen;
 
         group.addOwner(user);
 

--- a/connet/src/main/java/houseInception/connet/domain/group/GroupUser.java
+++ b/connet/src/main/java/houseInception/connet/domain/group/GroupUser.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static houseInception.connet.domain.Status.ALIVE;
+import static houseInception.connet.domain.Status.DELETED;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,5 +38,9 @@ public class GroupUser extends BaseTime {
         this.user = user;
         this.group = group;
         this.isOwner = isOwner;
+    }
+
+    protected void delete(){
+        this.status = DELETED;
     }
 }

--- a/connet/src/main/java/houseInception/connet/dto/group/GroupUserResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/group/GroupUserResDto.java
@@ -1,0 +1,26 @@
+package houseInception.connet.dto.group;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupUserResDto {
+
+    private Long userId;
+    private String userName;
+    private String userProfile;
+    private boolean isActive;
+    private boolean isOwner;
+
+    @QueryProjection
+
+    public GroupUserResDto(Long userId, String userName, String userProfile, boolean isActive, boolean isOwner) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfile = userProfile;
+        this.isActive = isActive;
+        this.isOwner = isOwner;
+    }
+}

--- a/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
@@ -19,6 +19,7 @@ public class EventGroupHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void acceptGroupInvite(GroupInviteAcceptEvent event){
+        log.info("옹?");
         groupService.addGroupUser(event.getUserId(), event.getGroupUuid());
     }
 }

--- a/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
@@ -1,0 +1,24 @@
+package houseInception.connet.event.handler;
+
+import houseInception.connet.event.domain.GroupInviteAcceptEvent;
+import houseInception.connet.service.GroupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EventGroupHandler {
+
+    public final GroupService groupService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void acceptGroupInvite(GroupInviteAcceptEvent event){
+        groupService.addGroupUser(event.getUserId(), event.getGroupUuid());
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
@@ -1,12 +1,15 @@
 package houseInception.connet.repository;
 
 
+import houseInception.connet.domain.group.GroupUser;
 import houseInception.connet.dto.group.GroupUserResDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupCustomRepository {
 
+    Optional<GroupUser> findGroupUser(Long groupId, Long userId);
     boolean existUserInGroup(Long userId, String groupUuid);
     Long countOfGroupUsers(Long groupId);
 

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
@@ -1,8 +1,13 @@
 package houseInception.connet.repository;
 
+
+import houseInception.connet.dto.group.GroupUserResDto;
+
 import java.util.List;
 
 public interface GroupCustomRepository {
 
     boolean existUserInGroup(Long userId, String groupUuid);
+
+    List<GroupUserResDto> getGroupUserList(String groupUuid);
 }

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface GroupCustomRepository {
 
     boolean existUserInGroup(Long userId, String groupUuid);
+    Long countOfGroupUsers(Long groupId);
 
     List<GroupUserResDto> getGroupUserList(String groupUuid);
 }

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.domain.QUser;
 import houseInception.connet.domain.Status;
+import houseInception.connet.domain.group.GroupUser;
 import houseInception.connet.domain.group.QGroup;
 import houseInception.connet.domain.group.QGroupUser;
 import houseInception.connet.dto.group.GroupUserResDto;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static houseInception.connet.domain.QUser.user;
 import static houseInception.connet.domain.group.QGroup.group;
@@ -21,6 +23,18 @@ import static houseInception.connet.domain.group.QGroupUser.groupUser;
 public class GroupCustomRepositoryImpl implements GroupCustomRepository{
 
     private final JPAQueryFactory query;
+
+    @Override
+    public Optional<GroupUser> findGroupUser(Long groupId, Long userId) {
+        GroupUser fetchedGroupUser = query
+                .selectFrom(groupUser)
+                .where(groupUser.group.id.eq(groupId),
+                        groupUser.user.id.eq(userId),
+                        groupUser.status.eq(Status.ALIVE))
+                .fetchOne();
+
+        return Optional.ofNullable(fetchedGroupUser);
+    }
 
     @Override
     public boolean existUserInGroup(Long userId, String groupUuid) {

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
@@ -37,6 +37,16 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository{
     }
 
     @Override
+    public Long countOfGroupUsers(Long groupId) {
+        return query
+                .select(groupUser.count())
+                .from(groupUser)
+                .where(groupUser.group.id.eq(groupId),
+                        groupUser.status.eq(Status.ALIVE))
+                .fetchOne();
+    }
+
+    @Override
     public List<GroupUserResDto> getGroupUserList(String groupUuid) {
         return query
                 .select(Projections.constructor(

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
@@ -1,12 +1,18 @@
 package houseInception.connet.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import houseInception.connet.domain.QUser;
 import houseInception.connet.domain.Status;
 import houseInception.connet.domain.group.QGroup;
 import houseInception.connet.domain.group.QGroupUser;
+import houseInception.connet.dto.group.GroupUserResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+import static houseInception.connet.domain.QUser.user;
 import static houseInception.connet.domain.group.QGroup.group;
 import static houseInception.connet.domain.group.QGroupUser.groupUser;
 
@@ -28,5 +34,27 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository{
                 .fetchOne();
 
         return count != null && count > 0;
+    }
+
+    @Override
+    public List<GroupUserResDto> getGroupUserList(String groupUuid) {
+        return query
+                .select(Projections.constructor(
+                        GroupUserResDto.class,
+                        user.id,
+                        user.userName,
+                        user.userProfile,
+                        user.isActive,
+                        groupUser.isOwner
+                ))
+                .from(groupUser)
+                .innerJoin(groupUser.group, group)
+                .innerJoin(groupUser.user, user)
+                .where(groupUser.status.eq(Status.ALIVE),
+                        group.groupUuid.eq(groupUuid))
+                .orderBy(
+                        groupUser.isOwner.desc(),
+                        user.userName.asc())
+                .fetch();
     }
 }

--- a/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long>, GroupCustomRepository {
 
-    Optional<Group> findByGroupUuid(String groupUuid);
+    Optional<Group> findByGroupUuidAndStatus(String groupUuid, Status status);
 
     boolean existsByGroupUuidAndStatus(String groupUuid, Status status);
 }

--- a/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
@@ -2,13 +2,21 @@ package houseInception.connet.repository;
 
 import houseInception.connet.domain.Status;
 import houseInception.connet.domain.group.Group;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long>, GroupCustomRepository {
 
     Optional<Group> findByGroupUuidAndStatus(String groupUuid, Status status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Group g WHERE g.groupUuid = :groupUuid AND g.status = :status")
+    Optional<Group> findByGroupUuidAndStatusWithLock(@Param("groupUuid") String groupUuid, @Param("status") Status status);
 
     boolean existsByGroupUuidAndStatus(String groupUuid, Status status);
 }

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -36,6 +36,8 @@ public enum BaseErrorCode implements StatusCode{
     ALREADY_IN_GROUP(400020, "이미 그룹에 속한 사용자입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_HAS_GROUP_INVITE(400021, "이미 그룹 초대된 사용자입니다.", HttpStatus.BAD_REQUEST),
     NO_SUCH_GROUP_INVITE(400022, "그룹에 초대되지 않은 사용자입니다.", HttpStatus.BAD_REQUEST),
+    PRIVATE_GROUP(400023, "개인 그룹입니다.", HttpStatus.BAD_REQUEST),
+    GROUP_USER_LIMIT(400024, "그룹 인원 제한이 초과되었습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_GOOGLE_TOKEN(40101, "유효하지 않은 Google Access Token입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -46,7 +46,7 @@ public enum BaseErrorCode implements StatusCode{
     //5XX 서버 에러
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
     CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
-    CAN_NOT_UPLOAD_FILE_TO_S3(50002, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);
+    CAN_NOT_UPLOAD_FILE_TO_S3(50002, "파일 업로드가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private int code; //서버 내부 오류 코드
     private String message; //서버 내부 오류 메세지

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -38,6 +38,7 @@ public enum BaseErrorCode implements StatusCode{
     NO_SUCH_GROUP_INVITE(400022, "그룹에 초대되지 않은 사용자입니다.", HttpStatus.BAD_REQUEST),
     PRIVATE_GROUP(400023, "개인 그룹입니다.", HttpStatus.BAD_REQUEST),
     GROUP_USER_LIMIT(400024, "그룹 인원 제한이 초과되었습니다.", HttpStatus.BAD_REQUEST),
+    OWNER_CAN_NOT_EXIT(400025, "방장은 퇴장할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_GOOGLE_TOKEN(40101, "유효하지 않은 Google Access Token입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN(40102, "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -70,8 +70,7 @@ public class GroupService {
 
     @Transactional
     public String enterGroup(Long userId, String groupUuid) {
-        Group group = groupRepository.findByGroupUuidAndStatusWithLock(groupUuid, Status.ALIVE)
-                .orElseThrow(() -> new GroupException(NO_SUCH_GROUP));
+        Group group = findGroupWithLock(groupUuid);
         checkOpenGroup(group);
         checkGroupLimit(group);
 
@@ -93,7 +92,9 @@ public class GroupService {
     @Transactional
     public void addGroupUser(Long userId, String groupUuid) {
         User user = validator.findUser(userId);
-        Group group = findGroup(groupUuid);
+
+        Group group = findGroupWithLock(groupUuid);
+        checkGroupLimit(group);
 
         group.addUser(user);
     }
@@ -124,6 +125,11 @@ public class GroupService {
 
     private Group findGroup(String groupUuid){
         return groupRepository.findByGroupUuidAndStatus(groupUuid, Status.ALIVE)
+                .orElseThrow(() -> new GroupException(NO_SUCH_GROUP));
+    }
+
+    private Group findGroupWithLock(String groupUuid){
+        return groupRepository.findByGroupUuidAndStatusWithLock(groupUuid, Status.ALIVE)
                 .orElseThrow(() -> new GroupException(NO_SUCH_GROUP));
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -1,5 +1,6 @@
 package houseInception.connet.service;
 
+import houseInception.connet.domain.Status;
 import houseInception.connet.domain.User;
 import houseInception.connet.domain.group.Group;
 import houseInception.connet.dto.group.GroupAddDto;
@@ -16,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 import static houseInception.connet.response.status.BaseErrorCode.INVALID_GROUP_TAG;
+import static houseInception.connet.response.status.BaseErrorCode.NO_SUCH_GROUP;
 import static houseInception.connet.service.util.FileUtil.getUniqueFileName;
 import static houseInception.connet.service.util.FileUtil.isInValidFile;
 
@@ -64,5 +66,18 @@ public class GroupService {
         s3ServiceProvider.uploadImage(newFileName, image);
 
         return s3UrlPrefix + newFileName;
+    }
+
+    @Transactional
+    public void addGroupUser(Long userId, String groupUuid) {
+        User user = validator.findUser(userId);
+        Group group = findGroup(groupUuid);
+
+        group.addUser(user);
+    }
+
+    private Group findGroup(String groupUuid){
+        return groupRepository.findByGroupUuidAndStatus(groupUuid, Status.ALIVE)
+                .orElseThrow(() -> new GroupException(NO_SUCH_GROUP));
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -84,7 +84,7 @@ public class GroupService {
 
     private void checkGroupLimit(Group group) {
         Long count = groupRepository.countOfGroupUsers(group.getId());
-        if (count != null && count > group.getUserLimit()) {
+        if (count != null && count >= group.getUserLimit()) {
             throw new GroupException(GROUP_USER_LIMIT);
         }
     }

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -89,6 +89,10 @@ public class GroupService {
         GroupUser groupUser = groupRepository.findGroupUser(group.getId(), userId)
                 .orElseThrow(() -> new GroupException(NOT_IN_GROUP));
 
+        if(groupUser.isOwner()){
+            throw new GroupException(OWNER_CAN_NOT_EXIT);
+        }
+
         group.removeUser(groupUser);
 
         return groupUser.getId();

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -17,8 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static houseInception.connet.response.status.BaseErrorCode.INVALID_GROUP_TAG;
-import static houseInception.connet.response.status.BaseErrorCode.NO_SUCH_GROUP;
+import static houseInception.connet.response.status.BaseErrorCode.*;
 import static houseInception.connet.service.util.FileUtil.getUniqueFileName;
 import static houseInception.connet.service.util.FileUtil.isInValidFile;
 
@@ -78,9 +77,17 @@ public class GroupService {
     }
 
     public List<GroupUserResDto> getGroupUserList(Long userId, String groupUuid) {
+        checkUserInGroup(userId, groupUuid);
+
         List<GroupUserResDto> result = groupRepository.getGroupUserList(groupUuid);
 
         return result;
+    }
+
+    private void checkUserInGroup(Long userId, String groupUuid){
+        if (!groupRepository.existUserInGroup(userId, groupUuid)) {
+            throw new GroupException(NOT_IN_GROUP);
+        }
     }
 
     private Group findGroup(String groupUuid){

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -4,6 +4,7 @@ import houseInception.connet.domain.Status;
 import houseInception.connet.domain.User;
 import houseInception.connet.domain.group.Group;
 import houseInception.connet.dto.group.GroupAddDto;
+import houseInception.connet.dto.group.GroupUserResDto;
 import houseInception.connet.exception.GroupException;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.GroupRepository;
@@ -74,6 +75,12 @@ public class GroupService {
         Group group = findGroup(groupUuid);
 
         group.addUser(user);
+    }
+
+    public List<GroupUserResDto> getGroupUserList(Long userId, String groupUuid) {
+        List<GroupUserResDto> result = groupRepository.getGroupUserList(groupUuid);
+
+        return result;
     }
 
     private Group findGroup(String groupUuid){

--- a/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
+++ b/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
@@ -1,0 +1,66 @@
+package houseInception.connet.event.handler;
+
+import houseInception.connet.domain.GroupInvite;
+import houseInception.connet.domain.User;
+import houseInception.connet.domain.group.Group;
+import houseInception.connet.repository.GroupInviteRepository;
+import houseInception.connet.repository.GroupRepository;
+import houseInception.connet.repository.UserRepository;
+import houseInception.connet.service.GroupInviteService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EventGroupHandlerTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    GroupRepository groupRepository;
+    @Autowired
+    GroupInviteRepository groupInviteRepository;
+    @Autowired
+    GroupInviteService groupInviteService;
+    @Autowired
+    EntityManager em;
+
+    User groupOwner;
+    User user1;
+    Group group;
+
+    @BeforeEach
+    void beforeEach(){
+        groupOwner = User.create("groupOwner", null, null, null);
+        user1 = User.create("user1", null, null, null);
+        userRepository.save(groupOwner);
+        userRepository.save(user1);
+
+        group = Group.create(groupOwner, "group", null, null, 3, false);
+        groupRepository.save(group);
+    }
+
+    @AfterEach
+    void afterEach(){
+        groupRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void acceptGroupInvite() {
+        //given
+        GroupInvite groupInvite1 = GroupInvite.create(group.getGroupUuid(), groupOwner, user1);
+        groupInviteRepository.save(groupInvite1);
+
+        //when
+        groupInviteService.acceptInvite(user1.getId(), group.getGroupUuid());
+
+        //then
+        assertThat(groupRepository.existUserInGroup(user1.getId(), group.getGroupUuid())).isTrue();
+    }
+}

--- a/connet/src/test/java/houseInception/connet/service/GroupInviteServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupInviteServiceTest.java
@@ -166,4 +166,5 @@ class GroupInviteServiceTest {
                 .extracting((res) -> res.getInviter().getUserId())
                 .contains(groupOwner.getId(), user1.getId());
     }
+
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -174,4 +174,40 @@ class GroupServiceTest {
         assertThatThrownBy(() -> groupService.enterGroup(user2.getId(), group.getGroupUuid()))
                 .isInstanceOf(GroupException.class);
     }
+
+    @Test
+    void exitGroup() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, false);
+        group.addUser(user2);
+        em.persist(group);
+
+        //when
+        groupService.exitGroup(user2.getId(), group.getGroupUuid());
+
+        //then
+        assertThat(groupRepository.existUserInGroup(user2.getId(), group.getGroupUuid())).isFalse();
+    }
+
+    @Test
+    void exitGroup_방장_퇴장_불가() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, false);
+        em.persist(group);
+
+        //when
+        assertThatThrownBy(() -> groupService.exitGroup(user1.getId(), group.getGroupUuid()))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    void exitGroup_그룹에_속하지_않는_유저() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, false);
+        em.persist(group);
+
+        //when
+        assertThatThrownBy(() -> groupService.exitGroup(user2.getId(), group.getGroupUuid()))
+                .isInstanceOf(GroupException.class);
+    }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -6,6 +6,7 @@ import houseInception.connet.domain.group.Group;
 import houseInception.connet.domain.group.GroupTag;
 import houseInception.connet.domain.group.GroupUser;
 import houseInception.connet.dto.group.GroupAddDto;
+import houseInception.connet.dto.group.GroupUserResDto;
 import houseInception.connet.exception.GroupException;
 import houseInception.connet.repository.GroupRepository;
 import houseInception.connet.repository.UserRepository;
@@ -109,5 +110,22 @@ class GroupServiceTest {
 
         assertThatThrownBy(() -> groupService.addGroup(user1.getId(), groupAddDto))
                 .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    void getGroupUserList() {
+        //given
+        Group group = Group.create(user2, "groupName", null, null, 3, true);
+        group.addUser(user1);
+        group.addUser(user3);
+        group.addUser(user4);
+        em.persist(group);
+
+        //when
+        List<GroupUserResDto> result = groupService.getGroupUserList(user1.getId(), group.getGroupUuid());
+
+        //then
+        assertThat(result).hasSize(4);
+        assertThat(result.get(0).getUserId()).isEqualTo(user2.getId()); //방장은 맨 첫번째로 조회
     }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -128,4 +128,15 @@ class GroupServiceTest {
         assertThat(result).hasSize(4);
         assertThat(result.get(0).getUserId()).isEqualTo(user2.getId()); //방장은 맨 첫번째로 조회
     }
+
+    @Test
+    void getGroupUserList_권한x() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, true);
+        em.persist(group);
+
+        //when
+        assertThatThrownBy(() -> groupService.getGroupUserList(user2.getId(), group.getGroupUuid()))
+                .isInstanceOf(GroupException.class);
+    }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -139,4 +139,39 @@ class GroupServiceTest {
         assertThatThrownBy(() -> groupService.getGroupUserList(user2.getId(), group.getGroupUuid()))
                 .isInstanceOf(GroupException.class);
     }
+
+    @Test
+    void enterGroup() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, true);
+        em.persist(group);
+
+        //when
+        groupService.enterGroup(user2.getId(), group.getGroupUuid());
+
+        //then
+        assertThat(groupRepository.existUserInGroup(user2.getId(), group.getGroupUuid())).isTrue();
+    }
+
+    @Test
+    void enterGroup_그룹_인원_제한_초과() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 1, true);
+        em.persist(group);
+
+        //when
+        assertThatThrownBy(() -> groupService.enterGroup(user2.getId(), group.getGroupUuid()))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    void enterGroup_private그룹() {
+        //given
+        Group group = Group.create(user1, "groupName", null, null, 3, false);
+        em.persist(group);
+
+        //when
+        assertThatThrownBy(() -> groupService.enterGroup(user2.getId(), group.getGroupUuid()))
+                .isInstanceOf(GroupException.class);
+    }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -1,5 +1,6 @@
 package houseInception.connet.service;
 
+import houseInception.connet.domain.Status;
 import houseInception.connet.domain.User;
 import houseInception.connet.domain.group.Group;
 import houseInception.connet.domain.group.GroupTag;
@@ -10,7 +11,6 @@ import houseInception.connet.repository.GroupRepository;
 import houseInception.connet.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,11 +19,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 @Transactional
@@ -78,7 +76,7 @@ class GroupServiceTest {
         String groupUuid = groupService.addGroup(user1.getId(), groupAddDto);
 
         //then
-        Group group = groupRepository.findByGroupUuid(groupUuid).orElseThrow();
+        Group group = groupRepository.findByGroupUuidAndStatus(groupUuid, Status.ALIVE).orElseThrow();
         assertThat(group.getGroupName()).isEqualTo(groupName);
 
         List<GroupUser> groupUserList = group.getGroupUserList();


### PR DESCRIPTION
## 관련 이슈 번호

- #91 

<br />

## 작업 사항

- 그룹 입장, 퇴장 기능 개발 및 테스트
- 그룹 멤버 조회 기능 개발 및 테스트
- GroupInviteAcceptEvent발생 시 그룹 멤버 추가 핸들러 로직 작성 및 테스트

<br />

## 기타 사항
그룹 입장 시 그룹 인원 제한을 초과하지 않는지 검증해야함. 하지만 검증하고 그룹 유저를 생성하는 사이 다른 유저가 입장할 수 있으므로 비관적 락을 사용하여 그룹 읽기, 쓰기에 락 생성. 따라서 제한된 인원 보장 가능.
<br />
