### PR TITLE
채팅 길이가 너무 길어 db상 발생하는 오류 등 수정 배포

### DIFF
--- a/connet/src/main/java/houseInception/connet/domain/GroupChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/GroupChat.java
@@ -27,7 +27,7 @@ public class GroupChat extends BaseTime{
 
     private Long groupId;
     private Long tapId;
-    
+
     @Lob
     @Column(columnDefinition = "MEDIUMTEXT")
     private String message;

--- a/connet/src/main/java/houseInception/connet/domain/GroupChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/GroupChat.java
@@ -27,6 +27,9 @@ public class GroupChat extends BaseTime{
 
     private Long groupId;
     private Long tapId;
+    
+    @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String message;
     private String image;
 

--- a/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoomChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoomChat.java
@@ -33,6 +33,7 @@ public class GptRoomChat extends BaseTime {
     private ChatterRole writerRole;
 
     @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -40,6 +40,7 @@ public class PrivateChat extends BaseTime {
     private ChatterRole chatTarget;
 
     @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String message;
     private String image;
 

--- a/connet/src/main/java/houseInception/connet/dto/group_invite/GroupInviteResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/group_invite/GroupInviteResDto.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @Getter
 public class GroupInviteResDto {
 
+    private String groupUuid;
     private String groupName;
     private String groupProfile;
     private DefaultUserResDto inviter;
 
     @QueryProjection
-
-    public GroupInviteResDto(String groupName, String groupProfile, DefaultUserResDto inviter) {
+    public GroupInviteResDto(String groupUuid, String groupName, String groupProfile, DefaultUserResDto inviter) {
         this.groupName = groupName;
         this.groupProfile = groupProfile;
         this.inviter = inviter;

--- a/connet/src/main/java/houseInception/connet/repository/GroupInviteCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupInviteCustomRepositoryImpl.java
@@ -27,6 +27,7 @@ public class GroupInviteCustomRepositoryImpl implements GroupInviteCustomReposit
         return query
                 .select(Projections.constructor(
                         GroupInviteResDto.class,
+                        group.groupUuid,
                         group.groupName,
                         group.groupProfile,
                         Projections.constructor(

--- a/connet/src/test/java/houseInception/connet/event/handler/EventChannelHandlerTest.java
+++ b/connet/src/test/java/houseInception/connet/event/handler/EventChannelHandlerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -48,13 +49,14 @@ class EventChannelHandlerTest {
     }
 
     @Test
-    void addDefaultChannelTap() {
+    void addDefaultChannelTap() throws InterruptedException {
         //given
         GroupAddDto groupAddDto = new GroupAddDto("group", null, null, List.of(), 3, false);
         String groupUuid = groupService.addGroup(user1.getId(), groupAddDto);
 
         //when
         List<ChannelTapDto> channelTaps = channelRepository.getChannelTapListOfGroup(groupUuid);
+        sleep(1000);
 
         //then
         assertThat(channelTaps).hasSize(1);

--- a/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
+++ b/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -52,13 +53,14 @@ class EventGroupHandlerTest {
     }
 
     @Test
-    void acceptGroupInvite() {
+    void acceptGroupInvite() throws InterruptedException {
         //given
         GroupInvite groupInvite1 = GroupInvite.create(group.getGroupUuid(), groupOwner, user1);
         groupInviteRepository.save(groupInvite1);
 
         //when
         groupInviteService.acceptInvite(user1.getId(), group.getGroupUuid());
+        sleep(1000);
 
         //then
         assertThat(groupRepository.existUserInGroup(user1.getId(), group.getGroupUuid())).isTrue();


### PR DESCRIPTION
- 채팅 메세지의 db 필드 단위를 lob중 medium text로 변경
- event publish subscribe구조 테스트를 위한 handler테스트 시 subscribe 로직 처리 시간에 따라 테스트 실패. 따라서 sleep을 넣어주어 테스트 시간을 지연해줌