### PR TITLE
그룹 채팅 오류, test 오류 등 수정

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/ChatEmojiController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/ChatEmojiController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RestController
 public class ChatEmojiController {
 
-    private ChatEmojiService chatEmojiService;
+    private final ChatEmojiService chatEmojiService;
 
     @PostMapping("/privateChats/{chatId}/emojis")
     public BaseResponse<DefaultIdDto> addEmojiOfPrivate(@PathVariable Long chatId,

--- a/connet/src/main/java/houseInception/connet/domain/GroupChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/GroupChat.java
@@ -27,7 +27,7 @@ public class GroupChat extends BaseTime{
 
     private Long groupId;
     private Long tapId;
-    
+
     @Lob
     @Column(columnDefinition = "MEDIUMTEXT")
     private String message;

--- a/connet/src/main/java/houseInception/connet/domain/GroupChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/GroupChat.java
@@ -27,6 +27,9 @@ public class GroupChat extends BaseTime{
 
     private Long groupId;
     private Long tapId;
+    
+    @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String message;
     private String image;
 

--- a/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoomChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoomChat.java
@@ -33,6 +33,7 @@ public class GptRoomChat extends BaseTime {
     private ChatterRole writerRole;
 
     @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
+++ b/connet/src/main/java/houseInception/connet/domain/privateRoom/PrivateChat.java
@@ -40,6 +40,7 @@ public class PrivateChat extends BaseTime {
     private ChatterRole chatTarget;
 
     @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
     private String message;
     private String image;
 

--- a/connet/src/main/java/houseInception/connet/dto/group_invite/GroupInviteResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/group_invite/GroupInviteResDto.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @Getter
 public class GroupInviteResDto {
 
+    private String groupUuid;
     private String groupName;
     private String groupProfile;
     private DefaultUserResDto inviter;
 
     @QueryProjection
-
-    public GroupInviteResDto(String groupName, String groupProfile, DefaultUserResDto inviter) {
+    public GroupInviteResDto(String groupUuid, String groupName, String groupProfile, DefaultUserResDto inviter) {
         this.groupName = groupName;
         this.groupProfile = groupProfile;
         this.inviter = inviter;

--- a/connet/src/main/java/houseInception/connet/repository/GroupInviteCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupInviteCustomRepositoryImpl.java
@@ -27,6 +27,7 @@ public class GroupInviteCustomRepositoryImpl implements GroupInviteCustomReposit
         return query
                 .select(Projections.constructor(
                         GroupInviteResDto.class,
+                        group.groupUuid,
                         group.groupName,
                         group.groupProfile,
                         Projections.constructor(

--- a/connet/src/test/java/houseInception/connet/event/handler/EventChannelHandlerTest.java
+++ b/connet/src/test/java/houseInception/connet/event/handler/EventChannelHandlerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -48,13 +49,14 @@ class EventChannelHandlerTest {
     }
 
     @Test
-    void addDefaultChannelTap() {
+    void addDefaultChannelTap() throws InterruptedException {
         //given
         GroupAddDto groupAddDto = new GroupAddDto("group", null, null, List.of(), 3, false);
         String groupUuid = groupService.addGroup(user1.getId(), groupAddDto);
 
         //when
         List<ChannelTapDto> channelTaps = channelRepository.getChannelTapListOfGroup(groupUuid);
+        sleep(1000);
 
         //then
         assertThat(channelTaps).hasSize(1);

--- a/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
+++ b/connet/src/test/java/houseInception/connet/event/handler/EventGroupHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -52,13 +53,14 @@ class EventGroupHandlerTest {
     }
 
     @Test
-    void acceptGroupInvite() {
+    void acceptGroupInvite() throws InterruptedException {
         //given
         GroupInvite groupInvite1 = GroupInvite.create(group.getGroupUuid(), groupOwner, user1);
         groupInviteRepository.save(groupInvite1);
 
         //when
         groupInviteService.acceptInvite(user1.getId(), group.getGroupUuid());
+        sleep(1000);
 
         //then
         assertThat(groupRepository.existUserInGroup(user1.getId(), group.getGroupUuid())).isTrue();


### PR DESCRIPTION
- 채팅이 너무 길때 database에서 오류 발생, Lob타입을 medium test 타입으로 필드 변경
- EventHandler 통합 테스트 시 subscribe 로직 처리 시간으로 테스트 실패 발생. sleep()을 통해 테스트 시간 지연 시켜줌
- 그룹 초대 목록 조회할때 groupUuid필드 추가
- ChatEmojiController에서 필드가 fianl이 아니라 생성자 주입으로 di가 발생하지 않던 문제 해결