### PR TITLE
UserDeleteEvent 발생 시 각 도메인에서 handling하는 로직 개발

### DIFF
--- a/connet/src/main/java/houseInception/connet/domain/group/Group.java
+++ b/connet/src/main/java/houseInception/connet/domain/group/Group.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static houseInception.connet.domain.Status.ALIVE;
+import static houseInception.connet.domain.Status.DELETED;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -71,6 +72,10 @@ public class Group extends BaseTime {
         }
     }
 
+    public void removeAllUser(){
+        this.groupUserList.forEach((groupUser) -> groupUser.delete());
+    }
+
     public boolean addTag(List<String> tags){
         if(!isValidTag(tags)){
             return false;
@@ -78,6 +83,10 @@ public class Group extends BaseTime {
 
         tags.forEach(tag -> this.groupTagList.add(new GroupTag(tag, this)));
         return true;
+    }
+
+    public void delete(){
+        this.status = DELETED;
     }
 
     private boolean isValidTag(List<String> tags){

--- a/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventFriendHandler.java
@@ -1,6 +1,7 @@
 package houseInception.connet.event.handler;
 
 import houseInception.connet.event.domain.UserBlockEvent;
+import houseInception.connet.event.domain.UserDeleteEvent;
 import houseInception.connet.service.FriendService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,8 +21,13 @@ public class EventFriendHandler {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-//    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteFriend(UserBlockEvent event){
         friendService.deleteFriend(event.getUserId(), event.getTargetId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteAllFriendsOfUser(UserDeleteEvent event){
+        friendService.deleteAllFriendsOfUser(event.getUserId());
     }
 }

--- a/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventGroupHandler.java
@@ -1,6 +1,7 @@
 package houseInception.connet.event.handler;
 
 import houseInception.connet.event.domain.GroupInviteAcceptEvent;
+import houseInception.connet.event.domain.UserDeleteEvent;
 import houseInception.connet.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,5 +21,11 @@ public class EventGroupHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void acceptGroupInvite(GroupInviteAcceptEvent event){
         groupService.addGroupUser(event.getUserId(), event.getGroupUuid());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void exitGroupsOfDeletedUser(UserDeleteEvent event){
+        groupService.exitGroupsOfUser(event.getUserId());
     }
 }

--- a/connet/src/main/java/houseInception/connet/event/handler/EventUserBlockHandler.java
+++ b/connet/src/main/java/houseInception/connet/event/handler/EventUserBlockHandler.java
@@ -1,0 +1,22 @@
+package houseInception.connet.event.handler;
+
+import houseInception.connet.event.domain.UserDeleteEvent;
+import houseInception.connet.service.UserBlockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class EventUserBlockHandler {
+
+    private final UserBlockService userBlockService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteAllUserBlockOfUser(UserDeleteEvent event){
+        userBlockService.deleteAllUserBlockOfUser(event.getUserId());
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public interface FriendCustomRepository {
 
+    void deleteAllFriendsOfUser(Long userId);
+
     List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto filterDto);
     List<DefaultUserResDto> getFriendWaitList(Long userId);
     List<DefaultUserResDto> getFriendRequestList(Long userId);

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -45,6 +45,16 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
     }
 
     @Override
+    public void deleteAllFriendsOfUser(Long userId) {
+        query.delete(friend)
+                .where(
+                        friend.receiver.id.eq(userId)
+                                .or(friend.sender.id.eq(userId))
+                )
+                .execute();
+    }
+
+    @Override
     public List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto filterDto) {
         return query.select(Projections.constructor(ActiveUserResDto.class,
                         user.id, user.userName, user.userProfile, user.isActive))

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
@@ -11,8 +11,9 @@ import java.util.Optional;
 
 public interface GroupCustomRepository {
 
-    List<GroupUser> findGroupUserListOfNotOwnerWithGroup(Long userId);
+    Optional<Group> findGroupWithGroupUsers(Long groupId);
     List<Group> findGroupListOfOwnerWithGroupUsers(Long userId);
+    List<GroupUser> findGroupUserListOfNotOwnerWithGroup(Long userId);
     Optional<GroupUser> findGroupUser(Long groupId, Long userId);
     Optional<GroupUser> findGroupUser(String groupUuid, Long userId);
 

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepository.java
@@ -1,5 +1,6 @@
 package houseInception.connet.repository;
 
+import houseInception.connet.domain.group.Group;
 import houseInception.connet.domain.group.GroupUser;
 import houseInception.connet.dto.group.*;
 import houseInception.connet.dto.user.CommonGroupOfUserResDto;
@@ -10,6 +11,8 @@ import java.util.Optional;
 
 public interface GroupCustomRepository {
 
+    List<GroupUser> findGroupUserListOfNotOwnerWithGroup(Long userId);
+    List<Group> findGroupListOfOwnerWithGroupUsers(Long userId);
     Optional<GroupUser> findGroupUser(Long groupId, Long userId);
     Optional<GroupUser> findGroupUser(String groupUuid, Long userId);
 

--- a/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupCustomRepositoryImpl.java
@@ -34,6 +34,20 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository{
     private final JPAQueryFactory query;
 
     @Override
+    public Optional<Group> findGroupWithGroupUsers(Long groupId) {
+        Group fetchedGroup = query
+                .selectFrom(group)
+                .leftJoin(group.groupUserList, groupUser).fetchJoin()
+                .where(
+                        group.id.eq(groupId),
+                        group.status.eq(ALIVE)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(fetchedGroup);
+    }
+
+    @Override
     public List<Group> findGroupListOfOwnerWithGroupUsers(Long userId) {
         QGroupUser subGroupUser = new QGroupUser("subGroupUser");
         return query

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepository.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 public interface UserBlockCustomRepository {
 
+    void deleteAllUserBlockOfUser(Long userId);
+
     List<DefaultUserResDto> getBlockUserList(Long userId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
@@ -19,6 +19,17 @@ public class UserBlockCustomRepositoryImpl implements UserBlockCustomRepository{
     private final JPAQueryFactory query;
 
     @Override
+    public void deleteAllUserBlockOfUser(Long userId) {
+        query
+                .delete(userBlock)
+                .where(
+                        userBlock.user.id.eq(userId)
+                                .or(userBlock.target.id.eq(userId))
+                )
+                .execute();
+    }
+
+    @Override
     public List<DefaultUserResDto> getBlockUserList(Long userId) {
         return query.select(Projections.constructor(DefaultUserResDto.class,
                         user.id, user.userName, user.userProfile))

--- a/connet/src/main/java/houseInception/connet/repository/UserRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository{
 
+    Optional<User> findByIdAndStatus(Long userId, Status status);
     Optional<User> findByEmailAndStatus(String email, Status status);
     boolean existsByEmailAndStatus(String email, Status status);
     boolean existsByIdAndStatus(Long userId, Status status);

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -135,6 +135,11 @@ public class FriendService {
         return new DataListResDto<>(0, friendList);
     }
 
+    @Transactional
+    public void deleteAllFriendsOfUser(Long userId) {
+        friendRepository.deleteAllFriendsOfUser(userId);
+    }
+
     private Friend findFriend(Long senderId, Long receiverId, FriendStatus acceptStatus){
         return friendRepository.findBySenderIdAndReceiverIdAndAcceptStatus(senderId, receiverId, acceptStatus)
                 .orElseThrow(() -> new FriendException(NO_SUCH_FRIEND));

--- a/connet/src/main/java/houseInception/connet/service/GroupService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupService.java
@@ -91,10 +91,12 @@ public class GroupService {
                 .orElseThrow(() -> new GroupException(NOT_IN_GROUP));
 
         if(groupUser.isOwner()){
-            throw new GroupException(OWNER_CAN_NOT_EXIT);
+            Group groupWithGroupUsers = groupRepository.findGroupWithGroupUsers(group.getId()).get();
+            groupWithGroupUsers.removeAllUser();
+            groupWithGroupUsers.delete();
+        }else {
+            group.removeUser(groupUser);
         }
-
-        group.removeUser(groupUser);
 
         return groupUser.getId();
     }

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -74,6 +74,10 @@ public class UserBlockService {
         return new DataListResDto<>(0, blockUserList);
     }
 
+    public void deleteAllUserBlockOfUser(Long userId) {
+        userBlockRepository.deleteAllUserBlockOfUser(userId);
+    }
+
     private UserBlock findUserBlock(Long userId, Long targetId){
         UserBlock userBlock = userBlockRepository.findByUserIdAndTargetId(userId, targetId).orElse(null);
         if (userBlock == null) {

--- a/connet/src/main/java/houseInception/connet/service/util/CommonDomainService.java
+++ b/connet/src/main/java/houseInception/connet/service/util/CommonDomainService.java
@@ -21,7 +21,7 @@ public class CommonDomainService {
     private final UserBlockRepository userBlockRepository;
 
     public User findUser(Long userId){
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndStatus(userId, ALIVE)
                 .orElseThrow(() -> new UserException(NO_SUCH_USER));
     }
 

--- a/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/FriendServiceTest.java
@@ -336,4 +336,23 @@ class FriendServiceTest {
         assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), ACCEPT)).isFalse();
         assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), ACCEPT)).isFalse();
     }
+
+    @Test
+    void deleteAllFriendsOfUser() {
+        //given
+        Friend friend1 = Friend.createFriend(user1, user2);
+        friend1.accept();
+        friendRepository.save(friend1);
+
+        Friend friend2 = Friend.createFriend(user2, user1);
+        friend2.accept();
+        friendRepository.save(friend2);
+
+        //when
+        friendService.deleteAllFriendsOfUser(user1.getId());
+
+        //then
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user1.getId(), user2.getId(), ACCEPT)).isFalse();
+        assertThat(friendRepository.existsBySenderIdAndReceiverIdAndAcceptStatus(user2.getId(), user1.getId(), ACCEPT)).isFalse();
+    }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -340,4 +340,34 @@ class GroupServiceTest {
         assertThatThrownBy(() -> groupService.getGroupDetail(user2.getId(), group.getGroupUuid()))
                 .isInstanceOf(GroupException.class);
     }
+
+    @Test
+    void exitGroupsOfUser() {
+        //given
+        Group group1 = Group.create(user1, "group1", null, null, 10, true);
+        group1.addUser(user2);
+        group1.addUser(user3);
+
+        Group group2 = Group.create(user2, "group2", null, null, 10, true);
+        group2.addUser(user1);
+
+        em.persist(group1);
+        em.persist(group2);
+
+        //when
+        groupService.exitGroupsOfUser(user1.getId());
+
+        //then
+        Group testGroup1 = groupRepository.findById(group1.getId()).get();
+        assertThat(testGroup1.getStatus()).isEqualTo(Status.DELETED);
+        assertThat(testGroup1.getGroupUserList())
+                .extracting(GroupUser::getStatus)
+                .containsExactly(Status.DELETED, Status.DELETED, Status.DELETED);
+
+        Group testGroup2 = groupRepository.findById(group2.getId()).get();
+        assertThat(testGroup2.getStatus()).isEqualTo(Status.ALIVE);
+        assertThat(testGroup2.getGroupUserList())
+                .extracting(GroupUser::getStatus)
+                .contains(Status.ALIVE, Status.DELETED);
+    }
 }

--- a/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GroupServiceTest.java
@@ -190,14 +190,19 @@ class GroupServiceTest {
     }
 
     @Test
-    void exitGroup_방장_퇴장_불가() {
+    void exitGroup_방장() {
         //given
         Group group = Group.create(user1, "groupName", null, null, 3, false);
+        group.addUser(user2);
         em.persist(group);
 
         //when
-        assertThatThrownBy(() -> groupService.exitGroup(user1.getId(), group.getGroupUuid()))
-                .isInstanceOf(GroupException.class);
+        groupService.exitGroup(user1.getId(), group.getGroupUuid());
+
+        //then
+        assertThat(group.getStatus()).isEqualTo(Status.DELETED);
+        assertThat(groupRepository.existUserInGroup(user1.getId(), group.getGroupUuid())).isFalse();
+        assertThat(groupRepository.existUserInGroup(user2.getId(), group.getGroupUuid())).isFalse();
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
@@ -133,4 +133,20 @@ class UserBlockServiceTest {
                 .extracting(DefaultUserResDto::getUserId)
                 .contains(user2.getId(), user3.getId());
     }
+
+    @Test
+    void deleteAllUserBlockOfUser() {
+        //given
+        UserBlock userBlock = UserBlock.create(user1, user2, REQUEST);
+        UserBlock reverseUserBlock = UserBlock.create(user2, user1, REQUEST);
+        em.persist(userBlock);
+        em.persist(reverseUserBlock);
+
+        //when
+        userBlockService.deleteAllUserBlockOfUser(user1.getId());
+
+        //then
+        assertThat(userBlockRepository.existsByUserIdAndTargetId(user1.getId(), user2.getId())).isFalse();
+        assertThat(userBlockRepository.existsByUserIdAndTargetId(user2.getId(), user1.getId())).isFalse();
+    }
 }


### PR DESCRIPTION
## 관련 이슈 번호

- #128 

<br />

## 작업 사항
UserDeleteEvent 발생 시 
- 탈퇴한 유저와의 모든 차단 관계 제거
- 탈퇴한 유저의 그룹 퇴장, 방장일 경우 그룹 삭제 및 그룹의 모든 유저 퇴장 

<br />

## 기타 사항

- 현재 탈퇴한 유저가 방장일 경우 그룹의 모든 유저를 퇴장 시켜야 함. Group어그리게이트의 루트는 Group이고 GroupUser은 하위 엔티티이기 때문에 루트 도메인에서 이를 dirty check를 통해 제거 하고 있음. 하지만 이는 GroupUser가 200명이면 200번의 query를 날려야함.
벌크 연산을 하면 되겠지만 어그리게이트의 일관성에 있어서 하위 엔티티를 직접 수정하는 쿼리를 날려도 될지 잘 모르겠음.
이에 대해 후에 생각해 봐야함


<br />
