### PR TITLE
Service, Repository 코드 컨벤션 변화 등

### DIFF
--- a/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoom.java
+++ b/connet/src/main/java/houseInception/connet/domain/gptRoom/GptRoom.java
@@ -75,4 +75,12 @@ public class GptRoom extends BaseTime {
     public void setTitle(String title) {
         this.title = title;
     }
+
+    public List<GptRoomUser> getGptRoomUsers() {
+        return List.copyOf(gptRoomUsers);
+    }
+
+    public List<GptRoomChat> getChats() {
+        return List.copyOf(chats);
+    }
 }

--- a/connet/src/main/java/houseInception/connet/repository/ChannelCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/ChannelCustomRepository.java
@@ -12,6 +12,7 @@ public interface ChannelCustomRepository {
 
     Optional<ChannelTap> findChannelTapWithChannel(Long tapId);
     Optional<ChannelTap> findChannelTap(Long tapId);
+
     boolean existsTapInGroup(Long tapId, String groupUuid);
 
     List<ChannelTapDto> getChannelTapListOfGroup(String groupUuid);

--- a/connet/src/main/java/houseInception/connet/repository/ChannelCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/ChannelCustomRepositoryImpl.java
@@ -59,8 +59,10 @@ public class ChannelCustomRepositoryImpl implements ChannelCustomRepository{
                 .from(channelTap)
                 .innerJoin(channelTap.channel, channel)
                 .innerJoin(group).on(group.id.eq(channel.groupId))
-                .where(channelTap.id.eq(tapId),
-                        group.groupUuid.eq(groupUuid))
+                .where(
+                        channelTap.id.eq(tapId),
+                        group.groupUuid.eq(groupUuid)
+                )
                 .fetchOne();
 
         return count != null && count > 0;
@@ -78,7 +80,7 @@ public class ChannelCustomRepositoryImpl implements ChannelCustomRepository{
                 ))
                 .from(channel)
                 .innerJoin(group).on(group.id.eq(channel.groupId))
-                .leftJoin(channelTap).on(channelTap.channel.id.eq(channel.id))
+                .leftJoin(channel.tapList, channelTap)
                 .where(group.groupUuid.eq(groupUuid))
                 .orderBy(channel.createdAt.asc(), channelTap.createdAt.asc())
                 .fetch();

--- a/connet/src/main/java/houseInception/connet/repository/ChatEmojiCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/ChatEmojiCustomRepositoryImpl.java
@@ -55,7 +55,8 @@ public class ChatEmojiCustomRepositoryImpl implements ChatEmojiCustomRepository{
                 .select(Projections.constructor(
                         ChatEmojiUserResDto.class,
                         user.userName
-                ))
+                        )
+                )
                 .from(chatEmoji)
                 .innerJoin(chatEmoji.user, user)
                 .where(

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepository.java
@@ -10,9 +10,9 @@ public interface FriendCustomRepository {
 
     void deleteAllFriendsOfUser(Long userId);
 
+    boolean existsFriendRequest(Long userId, Long targetId);
+
     List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto filterDto);
     List<DefaultUserResDto> getFriendWaitList(Long userId);
     List<DefaultUserResDto> getFriendRequestList(Long userId);
-
-    boolean existsFriendRequest(Long userId, Long targetId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -27,9 +27,11 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
         return query.select(Projections.constructor(DefaultUserResDto.class,
                         user.id, user.userName, user.userProfile))
                 .from(friend)
-                .join(user).on(user.id.eq(friend.sender.id))
-                .where(friend.receiver.id.eq(userId),
-                        friend.acceptStatus.eq(WAIT))
+                .innerJoin(friend.sender, user)
+                .where(
+                        friend.receiver.id.eq(userId),
+                        friend.acceptStatus.eq(WAIT)
+                )
                 .fetch();
     }
 
@@ -38,9 +40,11 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
         return query.select(Projections.constructor(DefaultUserResDto.class,
                         user.id, user.userName, user.userProfile))
                 .from(friend)
-                .join(user).on(user.id.eq(friend.receiver.id))
-                .where(friend.sender.id.eq(userId),
-                        friend.acceptStatus.eq(WAIT))
+                .innerJoin(friend.receiver, user)
+                .where(
+                        friend.sender.id.eq(userId),
+                        friend.acceptStatus.eq(WAIT)
+                )
                 .fetch();
     }
 
@@ -59,10 +63,12 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
         return query.select(Projections.constructor(ActiveUserResDto.class,
                         user.id, user.userName, user.userProfile, user.isActive))
                 .from(friend)
-                .join(user).on(user.id.eq(friend.receiver.id))
-                .where(friend.sender.id.eq(userId),
+                .innerJoin(friend.receiver, user)
+                .where(
+                        friend.sender.id.eq(userId),
                         friend.acceptStatus.eq(ACCEPT),
-                        userNameContains(filterDto.getUserName()))
+                        userNameContains(filterDto.getUserName())
+                )
                 .fetch();
     }
 

--- a/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface GptRoomCustomRepository {
 
     List<GptRoomChat> getChatListOfGptRoom(Long gptRoomId);
+
     boolean existsGptRoomUser(Long gptRoomId, Long userId, Status status);
 
     List<GptRoomListResDto> getGptRoomListByUserId(Long userId, int page);

--- a/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepositoryImpl.java
@@ -27,8 +27,10 @@ public class GptRoomCustomRepositoryImpl implements GptRoomCustomRepository {
     public List<GptRoomChat> getChatListOfGptRoom(Long gptRoomId) {
         return query
                 .selectFrom(gptRoomChat)
-                .where(gptRoomChat.gptRoom.id.eq(gptRoomId),
-                        gptRoomChat.status.eq(ALIVE))
+                .where(
+                        gptRoomChat.gptRoom.id.eq(gptRoomId),
+                        gptRoomChat.status.eq(ALIVE)
+                )
                 .orderBy(gptRoomChat.createdAt.asc())
                 .fetch();
     }
@@ -38,9 +40,11 @@ public class GptRoomCustomRepositoryImpl implements GptRoomCustomRepository {
         Long userCount = query
                 .select(gptRoomUser.count())
                 .from(gptRoomUser)
-                .where(gptRoomUser.gptRoom.id.eq(gptRoomId),
+                .where(
+                        gptRoomUser.gptRoom.id.eq(gptRoomId),
                         gptRoomUser.user.id.eq(userId),
-                        gptRoomUser.status.eq(status))
+                        gptRoomUser.status.eq(status)
+                )
                 .fetchOne();
 
         return userCount > 0;
@@ -52,11 +56,13 @@ public class GptRoomCustomRepositoryImpl implements GptRoomCustomRepository {
                 .select(Projections.constructor(GptRoomListResDto.class,
                         gptRoom.gptRoomUuid, gptRoom.title, gptRoom.createdAt))
                 .from(gptRoom)
-                .innerJoin(gptRoomUser).on(gptRoomUser.gptRoom.id.eq(gptRoom.id))
-                .innerJoin(user).on(user.id.eq(gptRoomUser.user.id))
-                .where(user.id.eq(userId),
+                .innerJoin(gptRoom.gptRoomUsers, gptRoomUser)
+                .innerJoin(gptRoomUser.user, user)
+                .where(
+                        user.id.eq(userId),
                         gptRoomUser.status.eq(ALIVE),
-                        gptRoom.status.eq(ALIVE))
+                        gptRoom.status.eq(ALIVE)
+                )
                 .orderBy(gptRoom.createdAt.desc())
                 .offset((page - 1) * 30)
                 .limit(31)
@@ -66,14 +72,22 @@ public class GptRoomCustomRepositoryImpl implements GptRoomCustomRepository {
     @Override
     public List<GptRoomChatResDto> getGptChatRoomChatList(Long gptRoomId, int page) {
         return query
-                .select(Projections.constructor(GptRoomChatResDto.class,
-                        gptRoomChat.id, gptRoomChat.content, gptRoomChat.writerRole, user.id, user.userName, user.userProfile, gptRoomChat.createdAt))
+                .select(Projections.constructor(
+                        GptRoomChatResDto.class,
+                        gptRoomChat.id,
+                        gptRoomChat.content,
+                        gptRoomChat.writerRole,
+                        user.id, user.userName,
+                        user.userProfile,
+                        gptRoomChat.createdAt))
                 .from(gptRoomChat)
-                .innerJoin(gptRoom).on(gptRoom.id.eq(gptRoomChat.gptRoom.id))
-                .leftJoin(gptRoomUser).on(gptRoomUser.gptRoom.id.eq(gptRoom.id))
-                .leftJoin(user).on(user.id.eq(gptRoomUser.user.id))
-                .where(gptRoom.id.eq(gptRoomId),
-                        gptRoomChat.status.eq(ALIVE))
+                .innerJoin(gptRoomChat.gptRoom, gptRoom)
+                .leftJoin(gptRoom.gptRoomUsers, gptRoomUser)
+                .leftJoin(gptRoomUser.user, user)
+                .where(
+                        gptRoom.id.eq(gptRoomId),
+                        gptRoomChat.status.eq(ALIVE)
+                )
                 .orderBy(gptRoomChat.createdAt.desc())
                 .offset((page - 1) * 30)
                 .limit(31)

--- a/connet/src/main/java/houseInception/connet/repository/GptRoomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GptRoomRepository.java
@@ -9,6 +9,4 @@ import java.util.Optional;
 public interface GptRoomRepository extends JpaRepository<GptRoom, Long>, GptRoomCustomRepository {
 
     Optional<GptRoom> findByGptRoomUuidAndStatus(String gptRoomUuid, Status status);
-
-    boolean existsByGptRoomUuidAndStatus(String gptRoomUuid, Status status);
 }

--- a/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupRepository.java
@@ -17,6 +17,4 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupCustom
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT g FROM Group g WHERE g.groupUuid = :groupUuid AND g.status = :status")
     Optional<Group> findByGroupUuidAndStatusWithLock(@Param("groupUuid") String groupUuid, @Param("status") Status status);
-
-    boolean existsByGroupUuidAndStatus(String groupUuid, Status status);
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -15,15 +15,13 @@ public interface PrivateRoomCustomRepository {
     Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid);
     Optional<PrivateRoom> findPrivateRoomByUsers(Long userId, Long targetId);
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
-    Optional<PrivateRoomUser> findTargetRoomUserInChatRoom(Long userId, Long privateRoomId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
     Optional<PrivateChat> findPrivateChatsById(Long privateChatId);
 
-    Map<Long, PrivateRoomResDto> getPrivateRoomList(Long userId, int page);
-    List<Long> getLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList);
-
+    List<Long> findLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList);
     boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId);
-    Long getPrivateRoomIdOfChat(Long privateChatId);
+    Long findPrivateRoomIdOfChat(Long privateChatId);
 
+    Map<Long, PrivateRoomResDto> getPrivateRoomList(Long userId, int page);
     List<PrivateChatResDto> getPrivateChatList(Long userId, Long privateRoomId, int page);
 }

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -105,7 +105,7 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     }
 
     @Override
-    public Long getPrivateRoomIdOfChat(Long privateChatId) {
+    public Long findPrivateRoomIdOfChat(Long privateChatId) {
         return query
                 .select(privateChat.privateRoom.id)
                 .from(privateChat)
@@ -114,20 +114,6 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                         privateChat.status.eq(ALIVE)
                 )
                 .fetchOne();
-    }
-
-    public Optional<PrivateRoomUser> findTargetRoomUserInChatRoom(Long userId, Long privateRoomId) {
-        PrivateRoomUser targetPrivateRoomUser = query
-                .selectFrom(privateRoomUser)
-                .innerJoin(privateRoom.privateRoomUsers, privateRoomUser)
-                .where(
-                        privateRoomUser.user.id.ne(userId),
-                        privateRoom.id.eq(privateRoomId),
-                        privateRoom.status.eq(ALIVE)
-                )
-                .fetchOne();
-
-        return Optional.ofNullable(targetPrivateRoomUser);
     }
 
     @Override
@@ -216,7 +202,7 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     }
 
     @Override
-    public List<Long> getLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList) {
+    public List<Long> findLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList) {
         return query.select(privateChat.privateRoom.id)
                 .from(privateChat)
                 .where(privateChat.privateRoom.id.in(privateRoomIdList))

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
@@ -31,12 +31,18 @@ public class UserBlockCustomRepositoryImpl implements UserBlockCustomRepository{
 
     @Override
     public List<DefaultUserResDto> getBlockUserList(Long userId) {
-        return query.select(Projections.constructor(DefaultUserResDto.class,
-                        user.id, user.userName, user.userProfile))
+        return query
+                .select(Projections.constructor(
+                DefaultUserResDto.class,
+                        user.id,
+                        user.userName,
+                        user.userProfile))
                 .from(userBlock)
-                .innerJoin(user).on(user.id.eq(userBlock.target.id))
-                .where(userBlock.user.id.eq(userId),
-                        userBlock.blockType.eq(REQUEST))
+                .innerJoin(userBlock.target, user)
+                .where(
+                        userBlock.user.id.eq(userId),
+                        userBlock.blockType.eq(REQUEST)
+                )
                 .orderBy(user.userName.asc())
                 .fetch();
     }

--- a/connet/src/main/java/houseInception/connet/repository/UserRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserRepository.java
@@ -10,6 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
 
     Optional<User> findByIdAndStatus(Long userId, Status status);
     Optional<User> findByEmailAndStatus(String email, Status status);
+
     boolean existsByEmailAndStatus(String email, Status status);
     boolean existsByIdAndStatus(Long userId, Status status);
     boolean existsByRefreshTokenAndStatus(String refreshToken, Status status);

--- a/connet/src/main/java/houseInception/connet/service/ChatEmojiService.java
+++ b/connet/src/main/java/houseInception/connet/service/ChatEmojiService.java
@@ -106,7 +106,7 @@ public class ChatEmojiService {
     }
 
     private Long findPrivateRoomIdOfChat(Long chatId){
-        Long privateRoomId = privateRoomRepository.getPrivateRoomIdOfChat(chatId);
+        Long privateRoomId = privateRoomRepository.findPrivateRoomIdOfChat(chatId);
         if(privateRoomId == null){
             throw new PrivateRoomException(NO_SUCH_CHAT);
         }

--- a/connet/src/main/java/houseInception/connet/service/GptRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/GptRoomService.java
@@ -50,8 +50,6 @@ public class GptRoomService {
 
             content = gptResDto.getContent();
         } else {
-            checkExistChatRoom(chatRoomUuid);
-
             gptRoom = findGptRoomByUuid(chatRoomUuid);
             checkGptRoomUser(gptRoom.getId(), userId);
             content = gptApiProvider.getChatCompletion(gptRoomChatAddDto.getMessage());
@@ -67,7 +65,6 @@ public class GptRoomService {
 
     @Transactional
     public Long updateGptRoom(Long userId, String gptRoomUuid, String title) {
-        checkExistChatRoom(gptRoomUuid);
         GptRoom gptRoom = findGptRoomByUuid(gptRoomUuid);
         checkGptRoomUser(gptRoom.getId(), userId);
 
@@ -78,7 +75,6 @@ public class GptRoomService {
 
     @Transactional
     public Long deleteGptRoom(Long userId, String gptRoomUuid) {
-        checkExistChatRoom(gptRoomUuid);
         GptRoom gptRoom = findGptRoomByUuid(gptRoomUuid);
         checkGptRoomUser(gptRoom.getId(), userId);
 
@@ -90,23 +86,16 @@ public class GptRoomService {
     public DataListResDto<GptRoomListResDto> getGptChatRoomList(Long userId, int page) {
         List<GptRoomListResDto> gptRoomList = gptRoomRepository.getGptRoomListByUserId(userId, page);
 
-        return new DataListResDto<GptRoomListResDto>(page, gptRoomList);
+        return new DataListResDto<>(page, gptRoomList);
     }
 
     public GptChatRoomChatListResDto getGptChatRoomChatList(Long userId, String gptRoomUuid, int page) {
-        checkExistChatRoom(gptRoomUuid);
         GptRoom gptRoom = findGptRoomByUuid(gptRoomUuid);
         checkGptRoomUser(gptRoom.getId(), userId);
 
         List<GptRoomChatResDto> chatList = gptRoomRepository.getGptChatRoomChatList(gptRoom.getId(), page);
 
         return new GptChatRoomChatListResDto(gptRoomUuid, gptRoom.getTitle(), page, chatList);
-    }
-
-    private void checkExistChatRoom(String gptRoomUuid) {
-        if(!gptRoomRepository.existsByGptRoomUuidAndStatus(gptRoomUuid, ALIVE)){
-            throw new GptRoomException(NO_SUCH_CHATROOM);
-        }
     }
 
     private void checkGptRoomUser(Long gptRoomId, Long userId){
@@ -116,11 +105,7 @@ public class GptRoomService {
     }
 
     private GptRoom findGptRoomByUuid(String gptRoomUuid){
-        GptRoom gptRoom = gptRoomRepository.findByGptRoomUuidAndStatus(gptRoomUuid, ALIVE).orElse(null);
-        if (gptRoom == null) {
-            throw new GptRoomException(NO_SUCH_CHATROOM);
-        }
-
-        return gptRoom;
+        return gptRoomRepository.findByGptRoomUuidAndStatus(gptRoomUuid, ALIVE)
+                .orElseThrow(() -> new GptRoomException(NO_SUCH_CHATROOM));
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -159,7 +159,7 @@ public class PrivateRoomService {
                 .stream()
                 .map(PrivateRoomResDto::getChatRoomId)
                 .toList();
-        List<Long> privateRoomIdOfActiveTimeOrder = privateRoomRepository.getLastChatTimeOfPrivateRooms(privateRoomIdList);
+        List<Long> privateRoomIdOfActiveTimeOrder = privateRoomRepository.findLastChatTimeOfPrivateRooms(privateRoomIdList);
 
         List<PrivateRoomResDto> resultList = privateRoomIdOfActiveTimeOrder.stream()
                 .map(privateRoomId -> privateRoomMap.get(privateRoomId))

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -79,12 +79,8 @@ public class UserBlockService {
     }
 
     private UserBlock findUserBlock(Long userId, Long targetId){
-        UserBlock userBlock = userBlockRepository.findByUserIdAndTargetId(userId, targetId).orElse(null);
-        if (userBlock == null) {
-            throw new UserBlockException(NO_SUCH_USER_BLOCK);
-        }
-
-        return userBlock;
+        return userBlockRepository.findByUserIdAndTargetId(userId, targetId)
+                .orElseThrow(() -> new UserBlockException(NO_SUCH_USER_BLOCK));
     }
 
     private void checkAlreadyRequestBlock(UserBlock findUserBlock) {


### PR DESCRIPTION
## 관련 이슈 번호

- #135 

<br />

## 작업 사항

- Repository, Service에 코드 컨벤션 적용
- Service의 중복 검증 로직 제거
- GptRoom엔티티에 그룹 유저, 채팅 등 컬렉션을 반환할때 얕은 복사를 통해 리스트 복사 후 반환

<br />

## 기타 사항
<br />
