### PR TITLE
페이징이 적용되지 않는 데이터의 응답 객체에서 의미 없는 페이징 필드 제거

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/FriendController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/FriendController.java
@@ -9,6 +9,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequestMapping("/friends")
 @RequiredArgsConstructor
 @RestController
@@ -33,9 +35,9 @@ public class FriendController {
     }
 
     @GetMapping("/request")
-    public BaseResponse<DataListResDto<DefaultUserResDto>> getFriendRequestList(){
+    public BaseResponse<List<DefaultUserResDto>> getFriendRequestList(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<DefaultUserResDto> result = friendService.getFriendRequestList(userId);
+        List<DefaultUserResDto> result = friendService.getFriendRequestList(userId);
 
         return new BaseResponse<>(result);
     }
@@ -73,17 +75,17 @@ public class FriendController {
     }
 
     @GetMapping("/wait")
-    public BaseResponse<DataListResDto<DefaultUserResDto>> getFriendWaitList(){
+    public BaseResponse<List<DefaultUserResDto>> getFriendWaitList(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<DefaultUserResDto> result = friendService.getFriendWaitList(userId);
+        List<DefaultUserResDto> result = friendService.getFriendWaitList(userId);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping
-    public BaseResponse<DataListResDto<ActiveUserResDto>> getFriendList(@ModelAttribute FriendFilterDto friendFilter){
+    public BaseResponse<List<ActiveUserResDto>> getFriendList(@ModelAttribute FriendFilterDto friendFilter){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<ActiveUserResDto> result = friendService.getFriendList(userId, friendFilter);
+        List<ActiveUserResDto> result = friendService.getFriendList(userId, friendFilter);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/contoller/UserBlockController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/UserBlockController.java
@@ -1,12 +1,13 @@
 package houseInception.connet.contoller;
 
-import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.response.DefaultIdDto;
 import houseInception.connet.service.UserBlockService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/userBlocks")
 @RequiredArgsConstructor
@@ -32,9 +33,9 @@ public class UserBlockController {
     }
 
     @GetMapping
-    public BaseResponse<DataListResDto<DefaultUserResDto>> getBlockUserList(){
+    public BaseResponse<List<DefaultUserResDto>> getBlockUserList(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DataListResDto<DefaultUserResDto> result = userBlockService.getBlockUserList(userId);
+        List<DefaultUserResDto> result = userBlockService.getBlockUserList(userId);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/service/FriendService.java
+++ b/connet/src/main/java/houseInception/connet/service/FriendService.java
@@ -117,22 +117,16 @@ public class FriendService {
     }
 
 
-    public DataListResDto<DefaultUserResDto> getFriendRequestList(Long userId) {
-        List<DefaultUserResDto> requestReceivers = friendRepository.getFriendRequestList(userId);
-
-        return new DataListResDto<>(0, requestReceivers);
+    public List<DefaultUserResDto> getFriendRequestList(Long userId) {
+        return friendRepository.getFriendRequestList(userId);
     }
 
-    public DataListResDto<DefaultUserResDto> getFriendWaitList(Long userId) {
-        List<DefaultUserResDto> requestSenders = friendRepository.getFriendWaitList(userId);
-
-        return new DataListResDto<>(0, requestSenders);
+    public List<DefaultUserResDto> getFriendWaitList(Long userId) {
+        return friendRepository.getFriendWaitList(userId);
     }
 
-    public DataListResDto<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto friendFilter) {
-        List<ActiveUserResDto> friendList = friendRepository.getFriendList(userId, friendFilter);
-
-        return new DataListResDto<>(0, friendList);
+    public List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto friendFilter) {
+        return friendRepository.getFriendList(userId, friendFilter);
     }
 
     @Transactional

--- a/connet/src/main/java/houseInception/connet/service/UserBlockService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserBlockService.java
@@ -2,7 +2,6 @@ package houseInception.connet.service;
 
 import houseInception.connet.domain.user.User;
 import houseInception.connet.domain.UserBlock;
-import houseInception.connet.dto.DataListResDto;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.event.publisher.UserBlockEventPublisher;
 import houseInception.connet.exception.UserBlockException;
@@ -68,10 +67,8 @@ public class UserBlockService {
         return userBlock.getId();
     }
 
-    public DataListResDto<DefaultUserResDto> getBlockUserList(Long userId) {
-        List<DefaultUserResDto> blockUserList = userBlockRepository.getBlockUserList(userId);
-
-        return new DataListResDto<>(0, blockUserList);
+    public List<DefaultUserResDto> getBlockUserList(Long userId) {
+        return userBlockRepository.getBlockUserList(userId);
     }
 
     public void deleteAllUserBlockOfUser(Long userId) {

--- a/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/UserBlockServiceTest.java
@@ -125,7 +125,7 @@ class UserBlockServiceTest {
         em.persist(userBlock3);
 
         //when
-        List<DefaultUserResDto> result = userBlockService.getBlockUserList(user1.getId()).getData();
+        List<DefaultUserResDto> result = userBlockService.getBlockUserList(user1.getId());
 
         //then
         assertThat(result).hasSize(2);


### PR DESCRIPTION
## 관련 이슈 번호

- #135 

<br />

## 작업 사항

- 페이징이 필요 없는 조회 API의 응답에 page 필드와 함께 리스트가 객체로 감싸져 있음. 이를 제거.

<br />

## 기타 사항
<br />
