### PR TITLE
access token 검증 api 추가 및 유저 조회 응답 필드 추가

### DIFF
--- a/connet/src/main/java/houseInception/connet/contoller/LoginController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/LoginController.java
@@ -42,9 +42,9 @@ public class LoginController {
 
     @PostMapping("/refresh/check")
     public BaseResponse<Map<String, Boolean>> checkRefreshToken(@RequestBody @Valid RefreshDto refreshDto){
-        loginService.checkRefreshToken(refreshDto.getRefreshToken());
+        boolean isValid = loginService.checkRefreshToken(refreshDto.getRefreshToken());
 
-        return new BaseResponse<>(Map.of("isValid", true));
+        return new BaseResponse<>(Map.of("isValid", isValid));
     }
 
     @PostMapping("/access/check")

--- a/connet/src/main/java/houseInception/connet/contoller/LoginController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/LoginController.java
@@ -1,5 +1,6 @@
 package houseInception.connet.contoller;
 
+import houseInception.connet.dto.login.AccessTokenDto;
 import houseInception.connet.dto.login.TokenResDto;
 import houseInception.connet.dto.login.RefreshDto;
 import houseInception.connet.dto.login.SignInDto;
@@ -44,6 +45,13 @@ public class LoginController {
         loginService.checkRefreshToken(refreshDto.getRefreshToken());
 
         return new BaseResponse<>(Map.of("isValid", true));
+    }
+
+    @PostMapping("/access/check")
+    public BaseResponse<Map<String, Boolean>> checkAccessToken(@RequestBody @Valid AccessTokenDto accessTokenDto){
+        boolean isValid = loginService.checkAccessToken(accessTokenDto.getAccessToken());
+
+        return new BaseResponse<>(Map.of("isValid", isValid));
     }
 
     @PostMapping("/sign-out")

--- a/connet/src/main/java/houseInception/connet/contoller/UserController.java
+++ b/connet/src/main/java/houseInception/connet/contoller/UserController.java
@@ -4,6 +4,7 @@ import houseInception.connet.domain.user.Setting;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.dto.user.CommonGroupOfUserResDto;
 import houseInception.connet.dto.user.SettingUpdateDto;
+import houseInception.connet.dto.user.UserProfileResDto;
 import houseInception.connet.dto.user.UserProfileUpdateDto;
 import houseInception.connet.response.BaseResponse;
 import houseInception.connet.response.DefaultIdDto;
@@ -22,17 +23,17 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping
-    public BaseResponse<DefaultUserResDto> getSelfProfile(){
+    public BaseResponse<UserProfileResDto> getSelfProfile(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DefaultUserResDto result = userService.getSelfProfile(userId);
+        UserProfileResDto result = userService.getSelfProfile(userId);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping("/{userId}")
-    public BaseResponse<DefaultUserResDto> getUserProfile(){
+    public BaseResponse<UserProfileResDto> getUserProfile(){
         Long userId = UserAuthorizationUtil.getLoginUserId();
-        DefaultUserResDto result = userService.getUserProfile(userId);
+        UserProfileResDto result = userService.getUserProfile(userId);
 
         return new BaseResponse<>(result);
     }

--- a/connet/src/main/java/houseInception/connet/dto/login/AccessTokenDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/login/AccessTokenDto.java
@@ -1,0 +1,15 @@
+package houseInception.connet.dto.login;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessTokenDto {
+
+    @NotBlank
+    private String accessToken;
+}

--- a/connet/src/main/java/houseInception/connet/dto/user/UserProfileResDto.java
+++ b/connet/src/main/java/houseInception/connet/dto/user/UserProfileResDto.java
@@ -1,0 +1,31 @@
+package houseInception.connet.dto.user;
+
+import com.querydsl.core.annotations.QueryProjection;
+import houseInception.connet.domain.user.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserProfileResDto {
+
+    private Long userId;
+    private String userName;
+    private String userProfile;
+    private String userDescription;
+
+    @QueryProjection
+    public UserProfileResDto(Long userId, String userName, String userProfile, String userDescription) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfile = userProfile;
+        this.userDescription = userDescription;
+    }
+
+    public UserProfileResDto(User user) {
+        this.userId = user.getId();
+        this.userName = user.getUserName();
+        this.userProfile = user.getUserProfile();
+        this.userDescription = user.getUserDescription();
+    }
+}

--- a/connet/src/main/java/houseInception/connet/exception/BaseExceptionHandler.java
+++ b/connet/src/main/java/houseInception/connet/exception/BaseExceptionHandler.java
@@ -47,9 +47,15 @@ public class BaseExceptionHandler {
         return BaseErrorResponse.get(NOT_FOUND);
     }
 
+    @ExceptionHandler(SerializationException.class)
+    public ResponseEntity<BaseErrorResponse> handleSerializationException(SerializationException e) {
+        log.error("{}:{}<{}:{}>", e.getStatus().getCode(), e.getStatus().getHttpStatus().getReasonPhrase(), e.getStatus().getMessage(), e.getPayload(), e);
+        return BaseErrorResponse.get(e.getStatus());
+    }
+
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<BaseErrorResponse> handleFileException(BaseException e) {
-        log.error("{}:{}<{}:{}>", e.getStatus().getCode(), e.getStatus().getHttpStatus().getReasonPhrase(), e.getStatus().getMessage(), e);
+        log.error("{}:{}<{}>", e.getStatus().getCode(), e.getStatus().getHttpStatus().getReasonPhrase(), e.getStatus().getMessage(), e);
         return BaseErrorResponse.get(e.getStatus());
     }
 

--- a/connet/src/main/java/houseInception/connet/exception/SerializationException.java
+++ b/connet/src/main/java/houseInception/connet/exception/SerializationException.java
@@ -1,0 +1,21 @@
+package houseInception.connet.exception;
+
+import houseInception.connet.response.status.StatusCode;
+import lombok.Getter;
+
+import static houseInception.connet.response.status.BaseErrorCode.CAN_NOT_PARSE;
+
+@Getter
+public class SerializationException extends BaseException{
+
+    private String payload;
+
+    public SerializationException(StatusCode status, String errorMessage, String payload) {
+        super(status, errorMessage);
+        this.payload = payload;
+    }
+
+    public SerializationException(String payload) {
+        this(CAN_NOT_PARSE, "SerializationException가 발생했습니다.", payload);
+    }
+}

--- a/connet/src/main/java/houseInception/connet/repository/AlarmCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/AlarmCustomRepositoryImpl.java
@@ -14,7 +14,8 @@ public class AlarmCustomRepositoryImpl implements AlarmCustomRepository{
 
     @Override
     public void deleteAlarmOver7days() {
-        query.delete(alarm)
+        query
+                .delete(alarm)
                 .where(alarm.createdAt.before(
                         java.time.LocalDateTime.now().minusDays(7)
                 ))

--- a/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/FriendCustomRepositoryImpl.java
@@ -24,8 +24,13 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
 
     @Override
     public List<DefaultUserResDto> getFriendWaitList(Long userId) {
-        return query.select(Projections.constructor(DefaultUserResDto.class,
-                        user.id, user.userName, user.userProfile))
+        return query
+                .select(Projections.constructor(
+                        DefaultUserResDto.class,
+                        user.id,
+                        user.userName,
+                        user.userProfile
+                ))
                 .from(friend)
                 .innerJoin(friend.sender, user)
                 .where(
@@ -37,8 +42,13 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
 
     @Override
     public List<DefaultUserResDto> getFriendRequestList(Long userId) {
-        return query.select(Projections.constructor(DefaultUserResDto.class,
-                        user.id, user.userName, user.userProfile))
+        return query
+                .select(Projections.constructor(
+                        DefaultUserResDto.class,
+                        user.id,
+                        user.userName,
+                        user.userProfile
+                ))
                 .from(friend)
                 .innerJoin(friend.receiver, user)
                 .where(
@@ -60,8 +70,14 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository{
 
     @Override
     public List<ActiveUserResDto> getFriendList(Long userId, FriendFilterDto filterDto) {
-        return query.select(Projections.constructor(ActiveUserResDto.class,
-                        user.id, user.userName, user.userProfile, user.isActive))
+        return query
+                .select(Projections.constructor(
+                        ActiveUserResDto.class,
+                        user.id,
+                        user.userName,
+                        user.userProfile,
+                        user.isActive
+                ))
                 .from(friend)
                 .innerJoin(friend.receiver, user)
                 .where(

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -38,7 +38,8 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
 
     @Override
     public Optional<PrivateRoom> findPrivateRoomWithUser(String privateRoomUuid) {
-        PrivateRoom findPrivateRoom = query.selectFrom(privateRoom)
+        PrivateRoom findPrivateRoom = query
+                .selectFrom(privateRoom)
                 .join(privateRoom.privateRoomUsers).fetchJoin()
                 .where(privateRoom.privateRoomUuid.eq(privateRoomUuid))
                 .fetchOne();
@@ -66,7 +67,8 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
 
     @Override
     public Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId) {
-        PrivateRoomUser findPrivateRoomUser = query.selectFrom(privateRoomUser)
+        PrivateRoomUser findPrivateRoomUser = query
+                .selectFrom(privateRoomUser)
                 .where(
                         privateRoomUser.privateRoom.id.eq(privateRoomId),
                         privateRoomUser.user.id.eq(userId)
@@ -78,14 +80,16 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
 
     @Override
     public List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId) {
-        return query.selectFrom(privateChat)
+        return query
+                .selectFrom(privateChat)
                 .where(privateChat.privateRoom.id.eq(privateRoomId))
                 .fetch();
     }
 
     @Override
     public Optional<PrivateChat> findPrivateChatsById(Long privateChatId) {
-        PrivateChat findPrivateChat = query.selectFrom(privateChat)
+        PrivateChat findPrivateChat = query
+                .selectFrom(privateChat)
                 .where(privateChat.id.eq(privateChatId))
                 .fetchOne();
 
@@ -94,7 +98,8 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
 
     @Override
     public boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId) {
-        Long count = query.select(privateRoomUser.count())
+        Long count = query
+                .select(privateRoomUser.count())
                 .from(privateRoomUser)
                 .where(
                         privateRoomUser.privateRoom.id.eq(privateRoomId),
@@ -138,8 +143,9 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
     public List<PrivateChatResDto> getPrivateChatList(Long userId, Long privateRoomId, int page) {
         QPrivateRoomUser subPrivateRoomUser = new QPrivateRoomUser("subPrivateRoomUser");
 
-        return query.select(Projections.constructor(
-                PrivateChatResDto.class,
+        return query
+                .select(Projections.constructor(
+                        PrivateChatResDto.class,
                         privateChat.id,
                         privateChat.message,
                         privateChat.image,

--- a/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserBlockCustomRepositoryImpl.java
@@ -33,7 +33,7 @@ public class UserBlockCustomRepositoryImpl implements UserBlockCustomRepository{
     public List<DefaultUserResDto> getBlockUserList(Long userId) {
         return query
                 .select(Projections.constructor(
-                DefaultUserResDto.class,
+                        DefaultUserResDto.class,
                         user.id,
                         user.userName,
                         user.userProfile))

--- a/connet/src/main/java/houseInception/connet/repository/UserCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserCustomRepository.java
@@ -1,9 +1,8 @@
 package houseInception.connet.repository;
 
-
-import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.user.UserProfileResDto;
 
 public interface UserCustomRepository {
 
-    DefaultUserResDto getUserProfile(Long userId);
+    UserProfileResDto getUserProfile(Long userId);
 }

--- a/connet/src/main/java/houseInception/connet/repository/UserCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/UserCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package houseInception.connet.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.dto.DefaultUserResDto;
+import houseInception.connet.dto.user.UserProfileResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,13 +17,14 @@ public class UserCustomRepositoryImpl implements UserCustomRepository{
     private final JPAQueryFactory query;
 
     @Override
-    public DefaultUserResDto getUserProfile(Long userId) {
+    public UserProfileResDto getUserProfile(Long userId) {
         return query
                 .select(Projections.constructor(
-                        DefaultUserResDto.class,
+                        UserProfileResDto.class,
                         user.id,
                         user.userName,
-                        user.userProfile
+                        user.userProfile,
+                        user.userDescription
                 ))
                 .from(user)
                 .where(

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -50,7 +50,8 @@ public enum BaseErrorCode implements StatusCode{
     //5XX 서버 에러
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
     CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
-    CAN_NOT_UPLOAD_FILE_TO_S3(50002, "파일 업로드가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    CAN_NOT_UPLOAD_FILE_TO_S3(50002, "파일 업로드가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    CAN_NOT_PARSE(50003, "json 직렬화 또는 역직렬화가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private int code; //서버 내부 오류 코드
     private String message; //서버 내부 오류 메세지

--- a/connet/src/main/java/houseInception/connet/service/LoginService.java
+++ b/connet/src/main/java/houseInception/connet/service/LoginService.java
@@ -87,4 +87,10 @@ public class LoginService {
     private boolean isNotServiceUser(String email){
         return !userRepository.existsByEmailAndStatus(email, ALIVE);
     }
+
+    private void checkValidToken(String refreshToken) {
+        if(!tokenProvider.validateToken(refreshToken)){
+            throw new InValidTokenException(INVALID_REFRESH_TOKEN);
+        }
+    }
 }

--- a/connet/src/main/java/houseInception/connet/service/LoginService.java
+++ b/connet/src/main/java/houseInception/connet/service/LoginService.java
@@ -64,10 +64,11 @@ public class LoginService {
         return new TokenResDto(accessToken, refreshToken);
     }
 
-    public void checkRefreshToken(String refreshToken) {
-        checkValidToken(refreshToken);
-        if(!userRepository.existsByRefreshTokenAndStatus(refreshToken, ALIVE)){
-            throw new InValidTokenException(INVALID_REFRESH_TOKEN);
+    public boolean checkRefreshToken(String refreshToken) {
+        if (tokenProvider.validateToken(refreshToken) && userRepository.existsByRefreshTokenAndStatus(refreshToken, ALIVE)) {
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -85,11 +86,5 @@ public class LoginService {
 
     private boolean isNotServiceUser(String email){
         return !userRepository.existsByEmailAndStatus(email, ALIVE);
-    }
-
-    private void checkValidToken(String refreshToken) {
-        if(!tokenProvider.validateToken(refreshToken)){
-            throw new InValidTokenException(INVALID_REFRESH_TOKEN);
-        }
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/LoginService.java
+++ b/connet/src/main/java/houseInception/connet/service/LoginService.java
@@ -71,6 +71,10 @@ public class LoginService {
         }
     }
 
+    public boolean checkAccessToken(String accessToken) {
+        return tokenProvider.validateToken(accessToken);
+    }
+
     @Transactional
     public Long signOut(Long userId) {
         User user = domainService.findUser(userId);

--- a/connet/src/main/java/houseInception/connet/service/UserService.java
+++ b/connet/src/main/java/houseInception/connet/service/UserService.java
@@ -5,6 +5,7 @@ import houseInception.connet.domain.user.User;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.dto.user.CommonGroupOfUserResDto;
 import houseInception.connet.dto.user.SettingUpdateDto;
+import houseInception.connet.dto.user.UserProfileResDto;
 import houseInception.connet.dto.user.UserProfileUpdateDto;
 import houseInception.connet.event.publisher.UserEventPublisher;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
@@ -32,14 +33,14 @@ public class UserService {
     private final S3ServiceProvider s3ServiceProvider;
     private final UserEventPublisher userEventPublisher;
 
-    public DefaultUserResDto getSelfProfile(Long userId) {
+    public UserProfileResDto getSelfProfile(Long userId) {
         return userRepository.getUserProfile(userId);
     }
 
-    public DefaultUserResDto getUserProfile(Long userId) {
+    public UserProfileResDto getUserProfile(Long userId) {
         User user = domainService.findUser(userId);
 
-        return new DefaultUserResDto(user);
+        return new UserProfileResDto(user);
     }
 
     @Transactional

--- a/connet/src/main/java/houseInception/connet/service/util/ObjectMapperUtil.java
+++ b/connet/src/main/java/houseInception/connet/service/util/ObjectMapperUtil.java
@@ -2,6 +2,7 @@ package houseInception.connet.service.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import houseInception.connet.exception.SerializationException;
 
 public class ObjectMapperUtil {
 
@@ -11,7 +12,8 @@ public class ObjectMapperUtil {
         try {
             return objectMapper.readValue(json, valueType);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("ObjectMapper를 통한 역직렬화가 불가능합니다.", e);
+
+            throw new SerializationException(json);
         }
     }
 
@@ -19,7 +21,7 @@ public class ObjectMapperUtil {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("ObjectMapper를 통한 직렬화가 불가능합니다.", e);
+            throw new SerializationException(value.getClass().getName());
         }
     }
 }

--- a/connet/src/main/resources/application.yml
+++ b/connet/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-        ddl-auto: create #주의 사용에 따라 create, update 사용 후 none으로 변경해주세요
+        ddl-auto: update #주의 사용에 따라 create, update 사용 후 none으로 변경해주세요
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/connet/src/test/java/houseInception/connet/service/UserServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import houseInception.connet.domain.user.User;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.dto.user.CommonGroupOfUserResDto;
 import houseInception.connet.dto.user.SettingUpdateDto;
+import houseInception.connet.dto.user.UserProfileResDto;
 import houseInception.connet.dto.user.UserProfileUpdateDto;
 import houseInception.connet.repository.FriendRepository;
 import houseInception.connet.repository.UserRepository;
@@ -56,7 +57,7 @@ class UserServiceTest {
     @Test
     void getSelfProfile() {
         //when
-        DefaultUserResDto result = userService.getSelfProfile(user1.getId());
+        UserProfileResDto result = userService.getSelfProfile(user1.getId());
 
         //then
         assertThat(result.getUserId()).isEqualTo(user1.getId());
@@ -66,7 +67,7 @@ class UserServiceTest {
     @Test
     void getUserProfile() {
         //when
-        DefaultUserResDto result = userService.getSelfProfile(user2.getId());
+        UserProfileResDto result = userService.getSelfProfile(user2.getId());
 
         //then
         assertThat(result.getUserId()).isEqualTo(user2.getId());


### PR DESCRIPTION
## 관련 이슈 번호

- #153 

<br />

## 작업 사항

- access token을 검증할 수 있는 api 개발
- 기존 refresh token 검증시 유효하지 않다면 오류를 throw하고 400번대 error를 반환했지만, 유효하지 않더라도 200반환 후 응답 body의 필드롤 통해 확인하도록 변경
- 유저 프로필 조회 시 유저의 소개글 응답 필드 추가

<br />

## 기타 사항
<br />
