### PR TITLE
개인 채팅 목록 조회 sql 오류 수정

### DIFF
--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -176,7 +176,10 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                                 JPAExpressions
                                         .select(subPrivateRoomUser.participationTime)
                                         .from(subPrivateRoomUser)
-                                        .where(subPrivateRoomUser.user.id.eq(userId))
+                                        .where(
+                                                subPrivateRoomUser.user.id.eq(userId),
+                                                subPrivateRoomUser.status.eq(ALIVE)
+                                                )
                         )
                 )
                 .offset((page - 1) * 30)


### PR DESCRIPTION
## 관련 이슈 번호

- #153 

<br />

## 작업 사항

- PrivateRoomCustomRepositoryImpl의 개인 채팅 목록 조회 메서드에서 subquery에 다수의 데이터 조회 발생 오류 수정

<br />

## 기타 사항
<br />
