### PR TITLE
채팅 기능 강화

### DIFF
--- a/connet/src/main/java/houseInception/connet/externalServiceProvider/gpt/GptApiProvider.java
+++ b/connet/src/main/java/houseInception/connet/externalServiceProvider/gpt/GptApiProvider.java
@@ -25,7 +25,7 @@ public class GptApiProvider {
     public String getChatCompletion(String content) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(GPT_API_KEY); // Authorization 헤더에 Bearer 토큰 추가
+        headers.setBearerAuth(GPT_API_KEY);
 
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("model", "gpt-4o");
@@ -56,10 +56,46 @@ public class GptApiProvider {
         }
     }
 
+    public String getChatCompletionWithPrevContent(String content, String prevContent) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(GPT_API_KEY);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-4o");
+        requestBody.put("max_completion_tokens", 16384);
+
+        Map<String, String> userMessage = new HashMap<>();
+        userMessage.put("role", "user");
+        userMessage.put("content", "이전에 저가 생성한 응답과 새로운 질문이 연관이 있다면 이전 응답을 기반으로 응답을 생성해줘. " +
+                "이전 응답 : [" + prevContent +"]" +
+                "새로운 질문 : [" + content + "]");
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(userMessage);
+        requestBody.put("messages", messages);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        // API 요청
+        ResponseEntity<String> response = restTemplate.exchange(
+                OPENAI_API_URL,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        try {
+            return objectMapper.readValue(response.getBody(), ChatCompletionResponse.class).getChoices().get(0).getMessage().getContent();
+        } catch (Exception e) {
+            throw new JsonParseException();
+        }
+    }
+
     public GptResDto getChatCompletionWithTitle(String content) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(GPT_API_KEY); // Authorization 헤더에 Bearer 토큰 추가
+        headers.setBearerAuth(GPT_API_KEY);
 
         Map<String, String> userMessage = new HashMap<>();
         userMessage.put("role", "user");

--- a/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepository.java
@@ -6,10 +6,12 @@ import houseInception.connet.dto.GptRoom.GptRoomChatResDto;
 import houseInception.connet.dto.GptRoom.GptRoomListResDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GptRoomCustomRepository {
 
     List<GptRoomChat> getChatListOfGptRoom(Long gptRoomId);
+    Optional<String> getLastGptChat(Long gptRoomId);
 
     boolean existsGptRoomUser(Long gptRoomId, Long userId, Status status);
 

--- a/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GptRoomCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package houseInception.connet.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import houseInception.connet.domain.ChatterRole;
 import houseInception.connet.domain.Status;
 import houseInception.connet.domain.gptRoom.*;
 import houseInception.connet.dto.GptRoom.GptRoomChatResDto;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.gptRoom.QGptRoom.gptRoom;
@@ -33,6 +35,23 @@ public class GptRoomCustomRepositoryImpl implements GptRoomCustomRepository {
                 )
                 .orderBy(gptRoomChat.createdAt.asc())
                 .fetch();
+    }
+
+    @Override
+    public Optional<String> getLastGptChat(Long gptRoomId) {
+        String chat = query
+                .select(gptRoomChat.content)
+                .from(gptRoomChat)
+                .where(
+                        gptRoomChat.gptRoom.id.eq(gptRoomId),
+                        gptRoomChat.writerRole.eq(ChatterRole.GPT),
+                        gptRoomChat.status.eq(ALIVE)
+                )
+                .orderBy(gptRoomChat.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(chat);
     }
 
     @Override

--- a/connet/src/main/java/houseInception/connet/repository/GroupChatCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupChatCustomRepository.java
@@ -10,6 +10,7 @@ public interface GroupChatCustomRepository{
 
     Optional<Long> findGroupIdOfChat(Long chatId);
     Map<Long, Long> findRecentGroupChatOfTaps(List<Long> channelTapList);
+    Optional<String> findLastGptChatOfTap(Long groupId);
 
     List<GroupChatResDto> getChatList(Long tapId, int page);
 

--- a/connet/src/main/java/houseInception/connet/repository/GroupChatCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/GroupChatCustomRepositoryImpl.java
@@ -7,6 +7,8 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.domain.ChatRoomType;
+import houseInception.connet.domain.ChatterRole;
+import houseInception.connet.domain.Status;
 import houseInception.connet.dto.DefaultUserResDto;
 import houseInception.connet.dto.groupChat.GroupChatResDto;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 
 import static houseInception.connet.domain.QChatEmoji.chatEmoji;
 import static houseInception.connet.domain.QGroupChat.groupChat;
+import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.group.QGroupUser.groupUser;
 import static houseInception.connet.domain.user.QUser.user;
 
@@ -53,6 +56,23 @@ public class GroupChatCustomRepositoryImpl implements GroupChatCustomRepository{
                         (tuple) -> tuple.get(groupChat.tapId),
                         (tuple) -> tuple.get(groupChat.id.max())
                 ));
+    }
+
+    @Override
+    public Optional<String> findLastGptChatOfTap(Long tapId) {
+        String chat = query
+                .select(groupChat.message)
+                .from(groupChat)
+                .where(
+                        groupChat.tapId.eq(tapId),
+                        groupChat.writerRole.eq(ChatterRole.GPT),
+                        groupChat.status.eq(ALIVE)
+                )
+                .orderBy(groupChat.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(chat);
     }
 
     @Override

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepository.java
@@ -17,6 +17,7 @@ public interface PrivateRoomCustomRepository {
     Optional<PrivateRoomUser> findPrivateRoomUser(Long privateRoomId, Long userId);
     List<PrivateChat> findPrivateChatsInPrivateRoom(Long privateRoomId);
     Optional<PrivateChat> findPrivateChatsById(Long privateChatId);
+    Optional<String> findLastGptChat(Long privateRoomId);
 
     List<Long> findLastChatTimeOfPrivateRooms(List<Long> privateRoomIdList);
     boolean existsAlivePrivateRoomUser(Long userId, Long privateRoomId);

--- a/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
+++ b/connet/src/main/java/houseInception/connet/repository/PrivateRoomCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import houseInception.connet.domain.ChatRoomType;
+import houseInception.connet.domain.ChatterRole;
 import houseInception.connet.domain.UserBlockType;
 import houseInception.connet.domain.privateRoom.*;
 import houseInception.connet.dto.DefaultUserResDto;
@@ -21,7 +22,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static houseInception.connet.domain.QChatEmoji.chatEmoji;
-import static houseInception.connet.domain.QChatReadLog.chatReadLog;
 import static houseInception.connet.domain.QUserBlock.userBlock;
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.domain.privateRoom.QPrivateChat.privateChat;
@@ -94,6 +94,23 @@ public class PrivateRoomCustomRepositoryImpl implements PrivateRoomCustomReposit
                 .fetchOne();
 
         return Optional.ofNullable(findPrivateChat);
+    }
+
+    @Override
+    public Optional<String> findLastGptChat(Long privateRoomId) {
+        String chat = query
+                .select(privateChat.message)
+                .from(privateChat)
+                .where(
+                        privateChat.privateRoom.id.eq(privateRoomId),
+                        privateChat.writerRole.eq(ChatterRole.GPT),
+                        privateChat.status.eq(ALIVE)
+                )
+                .orderBy(privateChat.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(chat);
     }
 
     @Override

--- a/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
+++ b/connet/src/main/java/houseInception/connet/response/status/BaseErrorCode.java
@@ -51,7 +51,8 @@ public enum BaseErrorCode implements StatusCode{
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
     CANT_NOT_PARSE_SOCKET_MESSAGE(50001, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR),
     CAN_NOT_UPLOAD_FILE_TO_S3(50002, "파일 업로드가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    CAN_NOT_PARSE(50003, "json 직렬화 또는 역직렬화가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    CAN_NOT_PARSE(50003, "json 직렬화 또는 역직렬화가 불가능합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNCONNECTED_SOCKET(50004, "소켓 연결이 불안정합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private int code; //서버 내부 오류 코드
     private String message; //서버 내부 오류 메세지

--- a/connet/src/main/java/houseInception/connet/service/GptRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/GptRoomService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static houseInception.connet.domain.Status.ALIVE;
 import static houseInception.connet.response.status.BaseErrorCode.NOT_CHATROOM_USER;
@@ -52,7 +53,10 @@ public class GptRoomService {
         } else {
             gptRoom = findGptRoomByUuid(chatRoomUuid);
             checkGptRoomUser(gptRoom.getId(), userId);
-            content = gptApiProvider.getChatCompletion(gptRoomChatAddDto.getMessage());
+            Optional<String> lastGptChat = gptRoomRepository.getLastGptChat(gptRoom.getId());
+            content =  lastGptChat.isEmpty()
+                    ? gptApiProvider.getChatCompletion(gptRoomChatAddDto.getMessage())
+                    : gptApiProvider.getChatCompletionWithPrevContent(gptRoomChatAddDto.getMessage(), lastGptChat.get());
         }
 
         GptRoomUser writer = gptRoom.getGptRoomUsers().get(0);

--- a/connet/src/main/java/houseInception/connet/service/GroupChatService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupChatService.java
@@ -8,6 +8,7 @@ import houseInception.connet.dto.groupChat.*;
 import houseInception.connet.exception.ChannelException;
 import houseInception.connet.exception.GroupChatException;
 import houseInception.connet.exception.GroupException;
+import houseInception.connet.exception.SocketException;
 import houseInception.connet.externalServiceProvider.gpt.GptApiProvider;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.ChannelRepository;
@@ -47,6 +48,8 @@ public class GroupChatService {
 
     @Transactional
     public GroupChatAddResDto addChat(Long userId, String groupUuid, GroupChatAddDto chatAddDto) {
+        checkConnectedUserSocket(userId);
+
         Long groupId = findGroupIdByUuid(groupUuid);
         checkExistTapInGroup(chatAddDto.getTapId(), groupUuid);
         checkValidContent(chatAddDto.getImage(), chatAddDto.getMessage());
@@ -80,6 +83,8 @@ public class GroupChatService {
 
     @Transactional
     public GroupGptChatAddResDto addGptChat(Long userId, String groupUuid, GroupGptChatAddDto chatAddDto) {
+        checkConnectedUserSocket(userId);
+        
         Long groupId = findGroupIdByUuid(groupUuid);
         checkExistTapInGroup(chatAddDto.getTapId(), groupUuid);
         GroupUser groupUser = findGroupUser(userId, groupUuid);
@@ -144,6 +149,12 @@ public class GroupChatService {
     private void checkExistGroupUser(Long userId, String groupUuid){
         if(!groupRepository.existUserInGroup(userId, groupUuid)){
             throw new GroupException(NOT_IN_GROUP);
+        }
+    }
+
+    private void checkConnectedUserSocket(Long userId){
+        if(!socketServiceProvider.isUserConnectedSocket(userId)){
+            throw new SocketException(UNCONNECTED_SOCKET);
         }
     }
 }

--- a/connet/src/main/java/houseInception/connet/service/GroupChatService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupChatService.java
@@ -84,7 +84,7 @@ public class GroupChatService {
     @Transactional
     public GroupGptChatAddResDto addGptChat(Long userId, String groupUuid, GroupGptChatAddDto chatAddDto) {
         checkConnectedUserSocket(userId);
-        
+
         Long groupId = findGroupIdByUuid(groupUuid);
         checkExistTapInGroup(chatAddDto.getTapId(), groupUuid);
         GroupUser groupUser = findGroupUser(userId, groupUuid);

--- a/connet/src/main/java/houseInception/connet/service/GroupChatService.java
+++ b/connet/src/main/java/houseInception/connet/service/GroupChatService.java
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static houseInception.connet.domain.ChatterRole.GPT;
 import static houseInception.connet.domain.ChatterRole.USER;
@@ -91,7 +92,10 @@ public class GroupChatService {
         GroupChatSocketDto userSocketDto = new GroupChatSocketDto(groupUuid, userChat, USER, user);
         sendMessageToGroupUsers(groupUserIds, userSocketDto);
 
-        String gptMessage = gptApiProvider.getChatCompletion(userChat.getMessage());
+        Optional<String> lastGptChat = groupChatRepository.findLastGptChatOfTap(chatAddDto.getTapId());
+        String gptMessage = lastGptChat.isEmpty()
+                ? gptApiProvider.getChatCompletion(userChat.getMessage())
+                : gptApiProvider.getChatCompletionWithPrevContent(userChat.getMessage(), lastGptChat.get());
         GroupChat gptChat = GroupChat.createGptToUser(groupId, chatAddDto.getTapId(), gptMessage);
         groupChatRepository.save(gptChat);
 

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -126,7 +126,11 @@ public class PrivateRoomService {
         checkRoomUserDeletedAndSetAlive(privateRoomReceiver, privateRoom, privateChat.getCreatedAt());
         checkRoomUserDeletedAndSetAlive(privateRoomSender, privateRoom, privateChat.getCreatedAt());
 
-        String gptResponse = gptApiProvider.getChatCompletion(message);
+
+        Optional<String> lastGptChat = privateRoomRepository.findLastGptChat(privateRoom.getId());
+        String gptResponse = lastGptChat.isEmpty()
+                ? gptApiProvider.getChatCompletion(message)
+                : gptApiProvider.getChatCompletionWithPrevContent(message, lastGptChat.get());
         PrivateChat gptPrivateChat = privateRoom.addGptToUserChat(gptResponse);
         em.flush();
 

--- a/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
+++ b/connet/src/main/java/houseInception/connet/service/PrivateRoomService.java
@@ -8,10 +8,12 @@ import houseInception.connet.domain.privateRoom.PrivateRoomUser;
 import houseInception.connet.dto.*;
 import houseInception.connet.dto.privateRoom.*;
 import houseInception.connet.exception.PrivateRoomException;
+import houseInception.connet.exception.SocketException;
 import houseInception.connet.externalServiceProvider.gpt.GptApiProvider;
 import houseInception.connet.externalServiceProvider.s3.S3ServiceProvider;
 import houseInception.connet.repository.ChatReadLogRepository;
 import houseInception.connet.repository.PrivateRoomRepository;
+import houseInception.connet.response.status.BaseErrorCode;
 import houseInception.connet.service.util.CommonDomainService;
 import houseInception.connet.socketManager.SocketServiceProvider;
 import houseInception.connet.socketManager.dto.PrivateChatSocketDto;
@@ -50,6 +52,8 @@ public class PrivateRoomService {
 
     @Transactional
     public PrivateChatAddResDto addPrivateChat(Long userId, Long targetId, PrivateChatAddDto chatAddDto) {
+        checkConnectedUserSocket(userId);
+
         User targetUser = domainService.findUser(targetId);
         User user = domainService.findUser(userId);
 
@@ -107,6 +111,8 @@ public class PrivateRoomService {
 
     @Transactional
     public GptPrivateChatAddResDto addGptChat(Long userId, Long targetId, String message) {
+        checkConnectedUserSocket(userId);
+
         User targetUser = domainService.findUser(targetId);
         User user = domainService.findUser(userId);
 
@@ -205,5 +211,11 @@ public class PrivateRoomService {
     private PrivateRoomUser findPrivateRoomUser(Long privateRoomId, Long userId){
         return privateRoomRepository.findPrivateRoomUser(privateRoomId, userId)
                 .orElseThrow(() -> new PrivateRoomException(NOT_CHATROOM_USER));
+    }
+
+    private void checkConnectedUserSocket(Long userId){
+        if(!socketServiceProvider.isUserConnectedSocket(userId)){
+            throw new SocketException(UNCONNECTED_SOCKET);
+        }
     }
 }

--- a/connet/src/test/java/houseInception/connet/service/GptRoomGptRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/GptRoomGptRoomServiceTest.java
@@ -10,6 +10,7 @@ import houseInception.connet.exception.GptRoomException;
 import houseInception.connet.repository.GptRoomRepository;
 import houseInception.connet.repository.UserRepository;
 import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import static houseInception.connet.domain.Status.DELETED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Slf4j
 @Transactional
 @SpringBootTest
 class GptRoomGptRoomServiceTest {
@@ -113,6 +115,26 @@ class GptRoomGptRoomServiceTest {
         //when
         assertThatThrownBy(() -> gptRoomService.addGptChat(newUser.getId(), gptRoomChatAddDto))
                 .isInstanceOf(GptRoomException.class);
+    }
+
+    @Test
+    void addGptChat_이전_응답_기반_생성() {
+        //given
+        GptRoom gptRoom = GptRoom.createGptRoom(user1);
+        em.persist(gptRoom);
+
+        String message1 = "Playstation 5은 몇달러야?";
+        GptRoomChatAddDto gptRoomChatAddDto1 = new GptRoomChatAddDto(gptRoom.getGptRoomUuid(), message1);
+        GptChatResDto gptChatResDto1 = gptRoomService.addGptChat(user1.getId(), gptRoomChatAddDto1);
+        log.info(gptChatResDto1.getMessage());
+
+        //when
+        String message = "현재 한국 환율로 바꿔서 말해줘";
+        GptRoomChatAddDto gptRoomChatAddDto2 = new GptRoomChatAddDto(gptRoom.getGptRoomUuid(), message);
+        GptChatResDto gptChatResDto2 = gptRoomService.addGptChat(user1.getId(), gptRoomChatAddDto2);
+
+        //then
+        log.info(gptChatResDto2.getMessage());
     }
 
     @Test

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -11,14 +11,17 @@ import houseInception.connet.exception.PrivateRoomException;
 import houseInception.connet.exception.UserBlockException;
 import houseInception.connet.repository.PrivateRoomRepository;
 import houseInception.connet.repository.UserRepository;
+import houseInception.connet.socketManager.SocketManager;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.util.List;
 
@@ -36,6 +39,8 @@ class PrivateRoomServiceTest {
     PrivateRoomRepository privateRoomRepository;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    SocketManager socketManager;
 
     @Autowired
     EntityManager em;
@@ -55,6 +60,11 @@ class PrivateRoomServiceTest {
         em.persist(user2);
         em.persist(user3);
         em.persist(user4);
+
+        socketManager.addSocket(user1.getId(), Mockito.mock(WebSocketSession.class));
+        socketManager.addSocket(user2.getId(), Mockito.mock(WebSocketSession.class));
+        socketManager.addSocket(user3.getId(), Mockito.mock(WebSocketSession.class));
+        socketManager.addSocket(user4.getId(), Mockito.mock(WebSocketSession.class));
     }
 
     @AfterEach

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -134,6 +134,23 @@ class PrivateRoomServiceTest {
     }
 
     @Test
+    void addGptChat_이전_응답_기반() {
+        //given
+        PrivateRoom privateRoom = PrivateRoom.create(user1, user2);
+        em.persist(privateRoom);
+
+        //when
+        GptPrivateChatAddResDto res1 = privateRoomService.addGptChat(user1.getId(), user2.getId(), "Playstation 4 pro는 언제 출시됐어?");
+        GptPrivateChatAddResDto res2 = privateRoomService.addGptChat(user1.getId(), user2.getId(), "달러 기준으로 얼마야?");
+        GptPrivateChatAddResDto res3 = privateRoomService.addGptChat(user1.getId(), user2.getId(), "한국 원화 기준으로 바꿔줄래");
+
+        //then
+        log.info(res1.getMessage());
+        log.info(res2.getMessage());
+        log.info(res3.getMessage());
+    }
+
+    @Test
     void getPrivateRoomList() {
         //given
         PrivateRoom privateRoom1 = PrivateRoom.create(user1, user2);

--- a/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
+++ b/connet/src/test/java/houseInception/connet/service/PrivateRoomServiceTest.java
@@ -8,6 +8,7 @@ import houseInception.connet.domain.user.User;
 import houseInception.connet.dto.chatEmoji.ChatEmojiResDto;
 import houseInception.connet.dto.privateRoom.*;
 import houseInception.connet.exception.PrivateRoomException;
+import houseInception.connet.exception.SocketException;
 import houseInception.connet.exception.UserBlockException;
 import houseInception.connet.repository.PrivateRoomRepository;
 import houseInception.connet.repository.UserRepository;
@@ -122,6 +123,18 @@ class PrivateRoomServiceTest {
                 .isInstanceOf(UserBlockException.class);
         assertThatThrownBy(() -> privateRoomService.addPrivateChat(user2.getId(), user1.getId(), chatAddDto))
                 .isInstanceOf(UserBlockException.class);
+    }
+
+    @Test
+    void addPrivateChat_소켓연결x() {
+        //given
+        User noSocketUser = User.create("noSocketUser", null, null, null);
+        em.persist(noSocketUser);
+
+        //when
+        PrivateChatAddDto chatAddDto = new PrivateChatAddDto("mess1", null);
+        assertThatThrownBy(() -> privateRoomService.addPrivateChat(noSocketUser.getId(), user2.getId(), chatAddDto))
+                .isInstanceOf(SocketException.class);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 번호

- #162 

<br />

## 작업 사항

- 개인 채팅방, 그룹방에서 채팅 전송 시 전송자의 소켓이 연결되어 있는지 검증, 연결되어 있지 않다면 오류 발생
- GPT채팅방, 개인 채팅방, 그룹방에서 gpt 채팅 전송시 이전에 생성된 gpt 응답이 있다면 이를 기반으로 응답 생성하도록 로직 강화

<br />

## 기타 사항
<br />
